### PR TITLE
chore: Refactor README and outputs for clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.6.0 (March 15, 2025)
+
+### Added
+
+- New outputs for `kms_key_arn and` `repository_arn`
+
+### Changed
+
+- Modified the `encryption_type` variable to simplify the description and validation.
+
+
 ## 0.5.0 (February 28, 2025)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_encryption_type"></a> [encryption\_type](#input\_encryption\_type) | The encryption type. Allowed values are "KMS" or "AES256". | `string` | n/a | yes |
+| <a name="input_encryption_type"></a> [encryption\_type](#input\_encryption\_type) | The encryption type. Allowed values are "KMS" or "AES256". | `string` | `"AES256"` | no |
 | <a name="input_force_delete"></a> [force\_delete](#input\_force\_delete) | Whether to delete the repository even if it contains images.<br/>Setting this to true will delete all images in the repository when the repository is deleted.<br/>Use with caution as this operation cannot be undone.<br/>Defaults to false for safety. | `bool` | `false` | no |
 | <a name="input_image_scanning_configuration"></a> [image\_scanning\_configuration](#input\_image\_scanning\_configuration) | Configuration block that defines image scanning configuration for the repository.<br/>Can be provided as either:<br/>1. A map of configuration options (legacy format)<br/>2. An object with scan\_on\_push boolean (new format)<br/>If null (default), will use the scan\_on\_push variable setting.<br/>Example: { scan\_on\_push = true } | `any` | `null` | no |
 | <a name="input_image_tag_mutability"></a> [image\_tag\_mutability](#input\_image\_tag\_mutability) | The tag mutability setting for the repository.<br/>- MUTABLE: Image tags can be overwritten<br/>- IMMUTABLE: Image tags cannot be overwritten (recommended for production)<br/>Defaults to MUTABLE to maintain backwards compatibility. | `string` | `"MUTABLE"` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -147,6 +147,7 @@ variable "tags" {
 variable "encryption_type" {
   description = "The encryption type. Allowed values are \"KMS\" or \"AES256\"."
   type        = string
+  default     = "AES256"
   validation {
     condition     = contains(["KMS", "AES256"], var.encryption_type)
     error_message = "encryption_type must be either \"KMS\" or \"AES256\"."


### PR DESCRIPTION
- Update the `README.md` to enhance the description of the `encryption_type` input and clarified allowed values.
- Add new outputs for `kms_key_arn` and `repository_arn` in `outputs.tf`.
- Modify the `encryption_type` variable in `variables.tf` to remove the default value, making it a required input.Test commit from terminal
- Update CHANGELOG