### PR TITLE
Update TF and AWS provider versions to latest recommended releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,14 +195,14 @@ This approach allows protecting repositories by default while providing a contro
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0.0 |
 
 ## Modules
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,14 @@
 terraform {
-  required_version = ">= 1.0.0"
+  # Require at least Terraform 1.3, which introduced important features
+  # such as moved blocks improvements and preconditions/validations enhancements
+  required_version = ">= 1.3.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0"
+      # Require AWS provider 5.x to ensure compatibility with the latest
+      # ECR features and future improvements.
+      version = ">= 5.0.0"
     }
   }
 }


### PR DESCRIPTION
This pull request updates the minimum required versions for Terraform and the AWS provider to ensure compatibility with newer features and improvements. 

### Dependency Version Updates:

* Updated the Terraform version requirement from `>= 1.0.0` to `>= 1.3.0` to leverage features such as moved block improvements and preconditions/validations enhancements (`versions.tf`, `README.md`). [[1]](diffhunk://#diff-dfd5848fa77a04d0343891fe859286cc210473d10f0e62c7f99f0d5ecf1a9927L2-R11) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L198-R205)
* Updated the AWS provider version requirement from `>= 4.0.0` to `>= 5.0.0` to ensure compatibility with the latest ECR features and future improvements (`versions.tf`, `README.md`). [[1]](diffhunk://#diff-dfd5848fa77a04d0343891fe859286cc210473d10f0e62c7f99f0d5ecf1a9927L2-R11) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L198-R205)