### PR TITLE
fix: Remove v prefix from release titles to match tag format

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -3,7 +3,8 @@
     ".": {
       "release-type": "terraform-module",
       "changelog-path": "CHANGELOG.md",
-      "include-v-in-tag": false
+      "include-v-in-tag": false,
+      "include-component-in-tag": false
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixed release-please configuration to ensure consistent formatting between release titles and tags by adding `include-component-in-tag: false`.

## Changes

- Added `"include-component-in-tag": false` to `.release-please-config.json`
- This ensures release titles don't include the "v" prefix, matching the existing tag format

## Background

The repository was experiencing inconsistent formatting where:
- Tags were correctly created without "v" prefix (due to `include-v-in-tag: false`)  
- Release titles were still using the component format which could include prefixes

## Test Plan

- [ ] Next release should have consistent tag and title formatting
- [ ] Both should use format like "0.16.2" instead of "v0.16.2"