### PR TITLE
fix: Add pull-request-title-pattern to control release title formatting

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -6,5 +6,6 @@
       "include-v-in-tag": false,
       "include-component-in-tag": false
     }
-  }
+  },
+  "pull-request-title-pattern": "chore: release ${version}"
 }


### PR DESCRIPTION
## Summary

Adds `pull-request-title-pattern` configuration to control release title formatting and remove the "v" prefix from release titles.

## Changes

- Added `"pull-request-title-pattern": "chore: release ${version}"` to `.release-please-config.json`
- This should generate release titles like "chore: release 0.16.3" instead of "v0.16.3"

## Background

The previous fix only addressed tag formatting but not release title formatting. Release titles were still showing "v0.16.2" while tags correctly showed "0.16.2".

## Test Plan

- [ ] Next release should have title format "chore: release X.Y.Z" instead of "vX.Y.Z"
- [ ] Tag format should remain unchanged (without "v" prefix)