### PR TITLE
fix: update release-please config to prevent v-prefix in release titles

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -4,8 +4,7 @@
       "release-type": "terraform-module",
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": false,
-      "include-component-in-tag": false
+      "tag-separator": ""
     }
-  },
-  "pull-request-title-pattern": "chore: release ${version}"
+  }
 }


### PR DESCRIPTION
## Summary
* Update `.release-please-config.json` to prevent v-prefix appearing in GitHub release titles
* Remove `include-component-in-tag` (redundant configuration)
* Add `tag-separator: ""` to explicitly control format
* Remove `pull-request-title-pattern` to avoid interference

## Background
This addresses an issue where `include-v-in-tag: false` correctly prevents v-prefix in Git tags but doesn't consistently prevent v-prefix in GitHub release titles for terraform-module release type.

## Changes
- Updated `.release-please-config.json` with explicit tag separator configuration
- Simplified configuration by removing redundant settings

## Test plan
- [ ] Merge this PR and verify next release has clean title format (e.g., "0.x.x" instead of "v0.x.x")
- [ ] Confirm Git tags remain clean without v-prefix