### PR TITLE
fix: try simple release type to prevent v-prefix in release titles

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -4,8 +4,7 @@
       "release-type": "terraform-module",
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": false,
-      "include-component-in-tag": false
+      "tag-separator": ""
     }
-  },
-  "pull-request-title-pattern": "chore: release ${version}"
+  }
 }

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,10 +1,9 @@
 {
   "packages": {
     ".": {
-      "release-type": "terraform-module",
+      "release-type": "simple",
       "changelog-path": "CHANGELOG.md",
-      "include-v-in-tag": false,
-      "tag-separator": ""
+      "include-v-in-tag": false
     }
   }
 }


### PR DESCRIPTION
## Summary
* Change `release-type` from `terraform-module` to `simple` to test v-prefix handling
* Remove `tag-separator` configuration (may not be needed with simple type)
* Keep `include-v-in-tag: false` for clean tags and titles

## Background
The `terraform-module` release type appears to handle git tags and GitHub release titles differently, causing v-prefix to appear in release titles despite `include-v-in-tag: false` setting.

## Hypothesis
The `simple` release type may handle v-prefix more consistently between git tags and GitHub release titles.

## Changes
- Updated `.release-please-config.json` to use `simple` release type
- Simplified configuration while maintaining clean version format goal

## Test plan
- [ ] Merge this PR and monitor next release
- [ ] Verify both git tag AND GitHub release title use clean format (e.g., "0.x.x")
- [ ] If successful, apply to other repositories

## Expected Result
Next release should have:
- Git tag: `0.19.2` ✅ (already working)
- Release title: `0.19.2` ❌➡️✅ (this is what we're trying to fix)