### PR TITLE
feat: add automatic v-prefix removal from release titles

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,3 +16,29 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: .release-please-config.json
+
+      - name: Remove v-prefix from release title
+        if: ${{ steps.release_please.outputs.release_created }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Get the release tag and current title
+          RELEASE_TAG="${{ steps.release_please.outputs.tag_name }}"
+          echo "Release tag: $RELEASE_TAG"
+
+          # Get current release info
+          CURRENT_RELEASE=$(gh release view "$RELEASE_TAG" --json name,tagName --repo ${{ github.repository }})
+          CURRENT_NAME=$(echo "$CURRENT_RELEASE" | jq -r '.name')
+          echo "Current release name: $CURRENT_NAME"
+
+          # Check if the release title has v-prefix but tag doesn't
+          if [[ "$CURRENT_NAME" =~ ^v[0-9] ]] && [[ ! "$RELEASE_TAG" =~ ^v[0-9] ]]; then
+            # Remove v-prefix from release title to match the clean tag
+            NEW_NAME="${CURRENT_NAME#v}"
+            echo "Updating release title from '$CURRENT_NAME' to '$NEW_NAME'"
+
+            gh release edit "$RELEASE_TAG" --title "$NEW_NAME" --repo ${{ github.repository }}
+            echo "✅ Release title updated successfully"
+          else
+            echo "ℹ️ No v-prefix found in release title or tag already has v-prefix - no changes needed"
+          fi


### PR DESCRIPTION
## Summary
* Add post-processing step to release-please workflow that automatically removes v-prefix from release titles
* Ensures consistent clean version format for both git tags AND GitHub release titles
* Only runs when a release is actually created by release-please

## How it works
1. Release-please creates release with clean git tag (e.g., `0.19.3`) but potentially v-prefixed title (e.g., `v0.19.3`)
2. New workflow step detects the mismatch
3. Automatically updates release title to match the clean tag format  
4. Logs all actions for transparency

## Logic
- ✅ If release title has v-prefix (`v0.19.3`) but tag is clean (`0.19.3`) → Remove v-prefix from title
- ✅ If both title and tag are already clean → No action needed
- ✅ If both title and tag have v-prefix → No action needed (respects intentional v-prefix)

## Expected Result
Future releases will have:
- Git tag: `0.19.3` ✅ (already working)
- Release title: `0.19.3` ✅ (automatically fixed)

## Test plan
- [ ] Merge this PR
- [ ] Trigger next release (make a small change)
- [ ] Verify release title is automatically cleaned
- [ ] If successful, apply to other repositories

This provides a robust solution that works regardless of release-please's internal behavior.