### PR TITLE
feat: complete release-please standardization across all repositories

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,11 +7,11 @@ on:
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       release_created: ${{ steps.release_please.outputs.release_created }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
         id: release_please
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,9 +1,11 @@
 {
   "packages": {
     ".": {
-      "release-type": "simple",
+      "release-type": "terraform-module",
       "changelog-path": "CHANGELOG.md",
-      "include-v-in-tag": false
+      "include-v-in-tag": false,
+      "include-component-in-tag": false
     }
-  }
+  },
+  "pull-request-title-pattern": "chore: release ${version}"
 }


### PR DESCRIPTION
## Summary
Final standardization of release-please configuration to match all other terraform repositories.

## Configuration Changes
- ✅ Change `release-type` from `"simple"` to `"terraform-module"` for terraform compliance
- ✅ Add `"include-component-in-tag": false` for completeness and consistency
- ✅ Add `"pull-request-title-pattern": "chore: release ${version}"` for consistent PR titles

## Workflow Changes  
- ✅ Pin Ubuntu version to `22.04` (was `ubuntu-latest`) for security and consistency
- ✅ Pin GitHub Action to specific commit hash `@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0` (was `@v4`) for security
- ✅ Maintain existing v-prefix cleanup functionality

## Result
After merging this PR, **all 6 terraform repositories will have identical release-please configurations** (except for legitimate branch name differences).

### Standardized Across All Repos:
- Same terraform-module release type
- Same v-prefix prevention configuration  
- Same pinned Ubuntu and GitHub Action versions
- Same v-prefix cleanup workflow step
- Same security and reliability standards

## Files Changed
- `.release-please-config.json` - Updated to standard terraform-module format
- `.github/workflows/release-please.yml` - Updated to use pinned, secure versions

This completes the comprehensive standardization effort across the entire terraform module ecosystem.