### PR TITLE
fix: Grant Bash permissions to Claude for pre-commit hooks

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -590,8 +590,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
+          # Allow Bash permissions for pre-commit hooks and documentation updates
+          allowed_tools: "Bash(pre-commit run --files),Bash(terraform fmt),Bash(terraform validate),Bash(terraform-docs)"
 
           # Dynamic prompt based on review mode
           direct_prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,26 +39,25 @@ jobs:
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-          
+
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"
-          
+
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
-          
+
           # Optional: Trigger when specific user is assigned to an issue
           # assignee_trigger: "claude-bot"
-          
-          # Optional: Allow Claude to run specific commands
-          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
-          
+
+          # Allow Bash permissions for pre-commit hooks and documentation updates
+          allowed_tools: "Bash(pre-commit run --files),Bash(terraform fmt),Bash(terraform validate),Bash(terraform-docs)"
+
           # Optional: Add custom instructions for Claude to customize its behavior for your project
           # custom_instructions: |
           #   Follow our coding standards
           #   Ensure all new code has tests
           #   Use TypeScript for new files
-          
+
           # Optional: Custom environment variables for Claude
           # claude_env: |
           #   NODE_ENV: test
-


### PR DESCRIPTION
## Summary
- Resolves #131 
- Add `allowed_tools` parameter to both Claude workflows to enable pre-commit automation

## Changes Made
- **`.github/workflows/claude-code-review.yml`**: Added Bash permissions for pre-commit tools
- **`.github/workflows/claude.yml`**: Added Bash permissions for pre-commit tools

## Permissions Added
- `Bash(pre-commit run --files)` - Run pre-commit hooks on specific files
- `Bash(terraform fmt)` - Format Terraform files
- `Bash(terraform validate)` - Validate Terraform syntax  
- `Bash(terraform-docs)` - Generate/update documentation

## Security
- Permissions are scoped to specific pre-commit related commands only
- Maintains existing security boundaries while enabling automation

## Test Plan
- [x] YAML syntax validation passed
- [x] Pre-commit hooks validated on commit
- [ ] Test Claude workflows can now run pre-commit commands in practice