### PR TITLE
fix: repository_arn output should return ARN instead of repository name

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,7 @@
 # ECR repository details
 output "repository_arn" {
   description = "ARN of the ECR repository"
-  value       = local.repository_id
+  value       = local.repository_arn
 }
 
 output "repository_url" {

--- a/repository.tf
+++ b/repository.tf
@@ -123,6 +123,7 @@ resource "aws_ecr_repository" "repo_protected" {
 # Repository output references for use in other resources and outputs
 locals {
   repository_id   = var.prevent_destroy ? one(aws_ecr_repository.repo_protected[*].id) : one(aws_ecr_repository.repo[*].id)
+  repository_arn  = var.prevent_destroy ? one(aws_ecr_repository.repo_protected[*].arn) : one(aws_ecr_repository.repo[*].arn)
   repository_name = var.prevent_destroy ? one(aws_ecr_repository.repo_protected[*].name) : one(aws_ecr_repository.repo[*].name)
   repository_url  = var.prevent_destroy ? one(aws_ecr_repository.repo_protected[*].repository_url) : one(aws_ecr_repository.repo[*].repository_url)
   registry_id     = var.prevent_destroy ? one(aws_ecr_repository.repo_protected[*].registry_id) : one(aws_ecr_repository.repo[*].registry_id)


### PR DESCRIPTION
Fixes issue where `repository_arn` output was returning the repository name instead of the actual ARN.

## Changes
- Add `local.repository_arn` using `.arn` attribute instead of `.id`
- Update `repository_arn` output to reference `local.repository_arn`

Fixes #137

Generated with [Claude Code](https://claude.ai/code)