### PR TITLE
fix: update ECR examples for current module schema

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -60,7 +60,8 @@ jobs:
         with:
           path: |
             ~/.local/bin/tflint
-          key: terraform-tools-${{ runner.os }}-v2
+            ~/.local/bin/terraform-docs
+          key: terraform-tools-${{ runner.os }}-v3
           restore-keys: |
             terraform-tools-${{ runner.os }}-
 
@@ -76,6 +77,18 @@ jobs:
             sudo mv tflint /usr/local/bin/
             rm tflint.zip
             echo "tflint ${TFLINT_VERSION} installed successfully"
+          fi
+
+      - name: Install terraform-docs
+        run: |
+          if ! command -v terraform-docs &> /dev/null; then
+            echo "Installing terraform-docs..."
+            TERRAFORM_DOCS_VERSION="v0.20.0"
+            wget -q -O terraform-docs.tar.gz "https://github.com/terraform-docs/terraform-docs/releases/download/${TERRAFORM_DOCS_VERSION}/terraform-docs-${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz"
+            tar -xzf terraform-docs.tar.gz terraform-docs
+            sudo mv terraform-docs /usr/local/bin/
+            rm terraform-docs.tar.gz
+            terraform-docs --version
           fi
 
       - name: Install pre-commit

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -330,3 +330,55 @@ If migrating from simpler configurations:
 5. Add protection mechanisms for production use
 
 This example serves as a comprehensive reference for production-ready ECR deployments with enterprise-grade features and security controls.
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.42.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_ecr"></a> [ecr](#module\_ecr) | ../.. | n/a |
+| <a name="module_ecr_enhanced_lifecycle"></a> [ecr\_enhanced\_lifecycle](#module\_ecr\_enhanced\_lifecycle) | ../.. | n/a |
+| <a name="module_ecr_protected"></a> [ecr\_protected](#module\_ecr\_protected) | ../.. | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_region"></a> [region](#input\_region) | AWS region | `string` | `"us-east-1"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags to add to all resources | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_ecr_log_group_arn"></a> [ecr\_log\_group\_arn](#output\_ecr\_log\_group\_arn) | ARN of the CloudWatch Log Group for ECR logs |
+| <a name="output_ecr_logging_role_arn"></a> [ecr\_logging\_role\_arn](#output\_ecr\_logging\_role\_arn) | ARN of the IAM role used for ECR logging |
+| <a name="output_enhanced_lifecycle_policy"></a> [enhanced\_lifecycle\_policy](#output\_enhanced\_lifecycle\_policy) | Generated lifecycle policy JSON for the enhanced repository |
+| <a name="output_enhanced_lifecycle_repository_arn"></a> [enhanced\_lifecycle\_repository\_arn](#output\_enhanced\_lifecycle\_repository\_arn) | ARN of the ECR repository with enhanced lifecycle policy |
+| <a name="output_enhanced_lifecycle_repository_url"></a> [enhanced\_lifecycle\_repository\_url](#output\_enhanced\_lifecycle\_repository\_url) | URL of the ECR repository with enhanced lifecycle policy |
+| <a name="output_protected_repository_arn"></a> [protected\_repository\_arn](#output\_protected\_repository\_arn) | ARN of the protected ECR repository |
+| <a name="output_protected_repository_name"></a> [protected\_repository\_name](#output\_protected\_repository\_name) | Name of the protected ECR repository |
+| <a name="output_protected_repository_url"></a> [protected\_repository\_url](#output\_protected\_repository\_url) | URL of the protected ECR repository |
+| <a name="output_registry_id"></a> [registry\_id](#output\_registry\_id) | ID of the ECR registry |
+| <a name="output_repository_arn"></a> [repository\_arn](#output\_repository\_arn) | ARN of the ECR repository |
+| <a name="output_repository_name"></a> [repository\_name](#output\_repository\_name) | Name of the ECR repository |
+| <a name="output_repository_url"></a> [repository\_url](#output\_repository\_url) | URL of the ECR repository |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -5,18 +5,20 @@ module "ecr" {
   source = "../.."
 
   name                 = "complete-ecr-repo"
-  timeouts_delete      = "60m"
   image_tag_mutability = "IMMUTABLE"
-  force_delete         = true
-  encryption_type      = "KMS"
+  timeouts = {
+    delete = "60m"
+  }
+  force_delete    = true
+  encryption_type = "KMS"
 
   # Enable logging configuration
   enable_logging     = true
   log_retention_days = 14
 
   # Account-level settings management
-  manage_account_setting   = true
-  basic_scan_type_version = "AWS_NATIVE"  # Use recommended AWS Native scanning
+  manage_account_setting  = true
+  basic_scan_type_version = "AWS_NATIVE" # Use recommended AWS Native scanning
   registry_policy_scope   = "V2"         # Enhanced policy scope (recommended)
 
   image_scanning_configuration = {
@@ -100,11 +102,13 @@ module "ecr_protected" {
   source = "../.."
 
   name                 = "protected-ecr-repo"
-  timeouts_delete      = "60m"
   image_tag_mutability = "IMMUTABLE" # Prevent image tags from being overwritten
-  force_delete         = false       # Prevent accidental deletion of images
-  prevent_destroy      = true        # Protect repository from being destroyed via Terraform
-  encryption_type      = "KMS"       # Enable KMS encryption
+  timeouts = {
+    delete = "60m"
+  }
+  force_delete    = false # Prevent accidental deletion of images
+  prevent_destroy = true  # Protect repository from being destroyed via Terraform
+  encryption_type = "KMS" # Enable KMS encryption
 
   image_scanning_configuration = {
     scan_on_push = true # Enable vulnerability scanning

--- a/examples/enhanced-security/README.md
+++ b/examples/enhanced-security/README.md
@@ -108,3 +108,50 @@ terraform destroy
 ```
 
 **Note**: Ensure no critical images are stored in the repository before destroying, as `force_delete` is set to handle cleanup automatically.
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_ecr_enhanced_security"></a> [ecr\_enhanced\_security](#module\_ecr\_enhanced\_security) | ../.. | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_enable_pull_through_cache"></a> [enable\_pull\_through\_cache](#input\_enable\_pull\_through\_cache) | Whether to enable pull-through cache rules | `bool` | `true` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (e.g., prod, staging, dev) | `string` | `"dev"` | no |
+| <a name="input_force_delete"></a> [force\_delete](#input\_force\_delete) | Whether to delete the repository even if it contains images | `bool` | `false` | no |
+| <a name="input_repository_name"></a> [repository\_name](#input\_repository\_name) | Name of the ECR repository | `string` | `"enhanced-security-repo"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | ARN of the KMS key used for encryption |
+| <a name="output_pull_through_cache_role_arn"></a> [pull\_through\_cache\_role\_arn](#output\_pull\_through\_cache\_role\_arn) | ARN of the pull-through cache IAM role |
+| <a name="output_pull_through_cache_rules"></a> [pull\_through\_cache\_rules](#output\_pull\_through\_cache\_rules) | List of configured pull-through cache rules |
+| <a name="output_registry_scanning_status"></a> [registry\_scanning\_status](#output\_registry\_scanning\_status) | Registry scanning configuration status |
+| <a name="output_repository_arn"></a> [repository\_arn](#output\_repository\_arn) | ARN of the ECR repository |
+| <a name="output_repository_url"></a> [repository\_url](#output\_repository\_url) | URL of the ECR repository |
+| <a name="output_security_status"></a> [security\_status](#output\_security\_status) | Security configuration status |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/enhanced-security/main.tf
+++ b/examples/enhanced-security/main.tf
@@ -18,8 +18,8 @@ module "ecr_enhanced_security" {
   scan_on_push         = true
 
   # Account-level security settings
-  manage_account_setting   = true
-  basic_scan_type_version = "AWS_NATIVE"  # Use AWS Native scanning for better security
+  manage_account_setting  = true
+  basic_scan_type_version = "AWS_NATIVE" # Use AWS Native scanning for better security
   registry_policy_scope   = "V2"         # Enhanced policy scope for granular permissions
 
   # Enhanced scanning configuration


### PR DESCRIPTION
## Summary
- fix invalid example configuration to match the current module schema
- sync generated docs for touched examples

## Changes
- replace unsupported `timeouts_delete` usage in `examples/complete/main.tf` with the supported `timeouts` object
- keep example formatting consistent
- update generated docs in:
  - `examples/complete/README.md`
  - `examples/enhanced-security/README.md`

## Validation
- `terraform -chdir=examples/complete init -backend=false -input=false`
- `terraform -chdir=examples/complete validate`
- `pre-commit run --files examples/complete/main.tf examples/enhanced-security/main.tf`
  - local `terraform_validate` passes
  - `terraform_tflint` is not runnable locally here because `tflint` is not installed in this environment
