### PR TITLE
ci: run full pre-commit on pull requests

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,6 +8,7 @@ on:
       - '**.tfvars'
       - '**.md'
       - '.pre-commit-config.yaml'
+      - '.github/workflows/pre-commit.yml'
   push:
     branches: [master]
     paths:
@@ -15,11 +16,12 @@ on:
       - '**.tfvars'
       - '**.md'
       - '.pre-commit-config.yaml'
+      - '.github/workflows/pre-commit.yml'
 
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: read
@@ -137,24 +139,8 @@ jobs:
       - name: Install pre-commit hooks
         run: pre-commit install-hooks
 
-      - name: Run pre-commit on all files (push to master)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      - name: Run pre-commit on all files
         run: pre-commit run --all-files
-
-      - name: Run pre-commit on changed files (pull request)
-        if: github.event_name == 'pull_request'
-        run: |
-          # Get the list of changed files
-          git fetch origin ${{ github.base_ref }}
-          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.tf' '*.tfvars' '*.md')
-
-          if [ -n "$CHANGED_FILES" ]; then
-            echo "Running pre-commit on changed files:"
-            echo "$CHANGED_FILES"
-            pre-commit run --files $CHANGED_FILES
-          else
-            echo "No relevant files changed, skipping pre-commit checks"
-          fi
 
       - name: Pre-commit summary
         if: always()

--- a/README.md
+++ b/README.md
@@ -1555,8 +1555,8 @@ For more details on the Terraform fixtures, see the [test directory README](test
 
 | Name | Version |
 |------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | >= 2.0.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.81.0 |
+| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
 
 ## Modules
 
@@ -1857,8 +1857,8 @@ For more details on the discovery system architecture, see `.github/scripts/disc
 
 | Name | Version |
 |------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | >= 2.0.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.81.0 |
+| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -337,7 +337,7 @@ This example serves as a comprehensive reference for production-ready ECR deploy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
 
 ## Modules
 

--- a/examples/enhanced-kms/README.md
+++ b/examples/enhanced-kms/README.md
@@ -223,7 +223,7 @@ kms_tags = {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
 
 ## Modules
 

--- a/examples/enhanced-security/README.md
+++ b/examples/enhanced-security/README.md
@@ -120,7 +120,7 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
 
 ## Modules
 

--- a/examples/monitoring/README.md
+++ b/examples/monitoring/README.md
@@ -144,7 +144,7 @@ aws ecr describe-repositories --repository-names my-app
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
 
 ## Modules
 

--- a/examples/multi-region/README.md
+++ b/examples/multi-region/README.md
@@ -137,7 +137,7 @@ Note: You must delete all images from the repositories before they can be delete
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.primary"></a> [aws.primary](#provider\_aws.primary) | >= 5.0.0 |
+| <a name="provider_aws.primary"></a> [aws.primary](#provider\_aws.primary) | 6.49.0 |
 
 ## Modules
 

--- a/examples/protected/README.md
+++ b/examples/protected/README.md
@@ -118,7 +118,7 @@ Remember: Both protection mechanisms must be removed in this order:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
 
 ## Modules
 

--- a/examples/pull-request-rules/README.md
+++ b/examples/pull-request-rules/README.md
@@ -114,7 +114,7 @@ The example can be customized by:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
 
 ## Modules
 

--- a/examples/pull-through-cache/README.md
+++ b/examples/pull-through-cache/README.md
@@ -131,7 +131,7 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
 
 ## Modules
 

--- a/examples/with-ecs-integration/README.md
+++ b/examples/with-ecs-integration/README.md
@@ -101,7 +101,7 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
 
 ## Modules
 

--- a/modules/kms/README.md
+++ b/modules/kms/README.md
@@ -196,7 +196,7 @@ See the `examples/` directory for complete usage examples.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
 
 ## Modules
 

--- a/modules/pull-through-cache/README.md
+++ b/modules/pull-through-cache/README.md
@@ -90,7 +90,7 @@ module "pull_through_cache" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
 
 ## Modules
 


### PR DESCRIPTION
## Summary
- Make pull-request pre-commit run the same `pre-commit run --all-files` command used on pushes to `master`
- Remove the changed-files-only PR path so generated docs drift is caught before merge

## Why
The current workflow can pass on PRs and then fail after merge because PRs only check changed files while `master` checks all files. This makes the PR gate match the post-merge gate and should prevent the recurring terraform-docs failure class.

## Validation
- `pre-commit run --files .github/workflows/pre-commit.yml`
- `terraform_docs --all-files` with `terraform-docs v0.20.0`
- `git diff --check`

Note: a local full `pre-commit run --all-files` was started after initializing modules, but exceeded the 10-minute local tool timeout during Terraform validation. The PR CI is now intentionally the authoritative full run.
