### PR TITLE
feat: add ECR repository creation templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1581,6 +1581,7 @@ For more details on the Terraform fixtures, see the [test directory README](test
 | [aws_ecr_replication_configuration.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_replication_configuration) | resource |
 | [aws_ecr_repository.repo](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
 | [aws_ecr_repository.repo_protected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
+| [aws_ecr_repository_creation_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_creation_template) | resource |
 | [aws_ecr_repository_policy.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy) | resource |
 | [aws_iam_role.ecr_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.pull_request_rules_webhook](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -1613,6 +1614,7 @@ For more details on the Terraform fixtures, see the [test directory README](test
 | <a name="input_enable_pull_through_cache"></a> [enable\_pull\_through\_cache](#input\_enable\_pull\_through\_cache) | Whether to create pull-through cache rules. | `bool` | `false` | no |
 | <a name="input_enable_registry_scanning"></a> [enable\_registry\_scanning](#input\_enable\_registry\_scanning) | Whether to enable enhanced scanning for the ECR registry. | `bool` | `false` | no |
 | <a name="input_enable_replication"></a> [enable\_replication](#input\_enable\_replication) | Whether to enable cross-region replication for the ECR registry. | `bool` | `false` | no |
+| <a name="input_enable_repository_creation_templates"></a> [enable\_repository\_creation\_templates](#input\_enable\_repository\_creation\_templates) | Whether to create ECR repository creation templates for repositories created by pull-through cache, create-on-push, or replication actions. | `bool` | `false` | no |
 | <a name="input_enable_secret_scanning"></a> [enable\_secret\_scanning](#input\_enable\_secret\_scanning) | Whether to enable secret scanning. Detects secrets in container images. | `bool` | `false` | no |
 | <a name="input_enable_tag_normalization"></a> [enable\_tag\_normalization](#input\_enable\_tag\_normalization) | Whether to enable automatic tag normalization. | `bool` | `true` | no |
 | <a name="input_enable_tag_validation"></a> [enable\_tag\_validation](#input\_enable\_tag\_validation) | Whether to enable tag validation to ensure compliance with organizational standards. | `bool` | `false` | no |
@@ -1655,6 +1657,7 @@ For more details on the Terraform fixtures, see the [test directory README](test
 | <a name="input_registry_scan_filters"></a> [registry\_scan\_filters](#input\_registry\_scan\_filters) | List of scan filters for filtering scan results when querying ECR findings. | <pre>list(object({<br/>    name   = string<br/>    values = list(string)<br/>  }))</pre> | `[]` | no |
 | <a name="input_registry_scan_type"></a> [registry\_scan\_type](#input\_registry\_scan\_type) | The type of scanning to configure for the registry. Either BASIC or ENHANCED. | `string` | `"ENHANCED"` | no |
 | <a name="input_replication_regions"></a> [replication\_regions](#input\_replication\_regions) | List of AWS regions to replicate ECR images to. | `list(string)` | `[]` | no |
+| <a name="input_repository_creation_templates"></a> [repository\_creation\_templates](#input\_repository\_creation\_templates) | List of ECR repository creation templates to create. Templates apply only to repositories Amazon ECR creates through pull-through cache, create-on-push, or replication actions. The resource\_tags field controls tags ECR applies to repositories created from the template and does not inherit the module-level tags variable. | <pre>list(object({<br/>    prefix          = string<br/>    applied_for     = list(string)<br/>    custom_role_arn = optional(string)<br/>    description     = optional(string)<br/>    encryption_configuration = optional(object({<br/>      encryption_type = optional(string, "AES256")<br/>      kms_key         = optional(string)<br/>    }))<br/>    image_tag_mutability = optional(string, "MUTABLE")<br/>    lifecycle_policy     = optional(string)<br/>    repository_policy    = optional(string)<br/>    resource_tags        = optional(map(string), {})<br/>  }))</pre> | `[]` | no |
 | <a name="input_required_tags"></a> [required\_tags](#input\_required\_tags) | List of tag keys that are required to be present. Empty list disables validation. | `list(string)` | `[]` | no |
 | <a name="input_scan_on_push"></a> [scan\_on\_push](#input\_scan\_on\_push) | Whether images should be scanned after being pushed to the repository. | `bool` | `true` | no |
 | <a name="input_scan_repository_filters"></a> [scan\_repository\_filters](#input\_scan\_repository\_filters) | List of repository filters to apply for registry scanning. Supports wildcards. | `list(string)` | <pre>[<br/>  "*"<br/>]</pre> | no |
@@ -1690,6 +1693,8 @@ For more details on the Terraform fixtures, see the [test directory README](test
 | <a name="output_replication_regions"></a> [replication\_regions](#output\_replication\_regions) | List of regions where ECR images are replicated to (if replication is enabled) |
 | <a name="output_replication_status"></a> [replication\_status](#output\_replication\_status) | Status of ECR replication configuration |
 | <a name="output_repository_arn"></a> [repository\_arn](#output\_repository\_arn) | ARN of the ECR repository |
+| <a name="output_repository_creation_template_status"></a> [repository\_creation\_template\_status](#output\_repository\_creation\_template\_status) | Status of ECR repository creation template configuration |
+| <a name="output_repository_creation_templates"></a> [repository\_creation\_templates](#output\_repository\_creation\_templates) | Map of ECR repository creation templates keyed by prefix |
 | <a name="output_repository_name"></a> [repository\_name](#output\_repository\_name) | Name of the ECR repository |
 | <a name="output_repository_policy_exists"></a> [repository\_policy\_exists](#output\_repository\_policy\_exists) | Whether a repository policy exists for this ECR repository |
 | <a name="output_repository_url"></a> [repository\_url](#output\_repository\_url) | URL of the ECR repository |
@@ -1883,6 +1888,7 @@ For more details on the discovery system architecture, see `.github/scripts/disc
 | [aws_ecr_replication_configuration.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_replication_configuration) | resource |
 | [aws_ecr_repository.repo](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
 | [aws_ecr_repository.repo_protected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
+| [aws_ecr_repository_creation_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_creation_template) | resource |
 | [aws_ecr_repository_policy.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy) | resource |
 | [aws_iam_role.ecr_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.pull_request_rules_webhook](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -1915,6 +1921,7 @@ For more details on the discovery system architecture, see `.github/scripts/disc
 | <a name="input_enable_pull_through_cache"></a> [enable\_pull\_through\_cache](#input\_enable\_pull\_through\_cache) | Whether to create pull-through cache rules. | `bool` | `false` | no |
 | <a name="input_enable_registry_scanning"></a> [enable\_registry\_scanning](#input\_enable\_registry\_scanning) | Whether to enable enhanced scanning for the ECR registry. | `bool` | `false` | no |
 | <a name="input_enable_replication"></a> [enable\_replication](#input\_enable\_replication) | Whether to enable cross-region replication for the ECR registry. | `bool` | `false` | no |
+| <a name="input_enable_repository_creation_templates"></a> [enable\_repository\_creation\_templates](#input\_enable\_repository\_creation\_templates) | Whether to create ECR repository creation templates for repositories created by pull-through cache, create-on-push, or replication actions. | `bool` | `false` | no |
 | <a name="input_enable_secret_scanning"></a> [enable\_secret\_scanning](#input\_enable\_secret\_scanning) | Whether to enable secret scanning. Detects secrets in container images. | `bool` | `false` | no |
 | <a name="input_enable_tag_normalization"></a> [enable\_tag\_normalization](#input\_enable\_tag\_normalization) | Whether to enable automatic tag normalization. | `bool` | `true` | no |
 | <a name="input_enable_tag_validation"></a> [enable\_tag\_validation](#input\_enable\_tag\_validation) | Whether to enable tag validation to ensure compliance with organizational standards. | `bool` | `false` | no |
@@ -1957,6 +1964,7 @@ For more details on the discovery system architecture, see `.github/scripts/disc
 | <a name="input_registry_scan_filters"></a> [registry\_scan\_filters](#input\_registry\_scan\_filters) | List of scan filters for filtering scan results when querying ECR findings. | <pre>list(object({<br/>    name   = string<br/>    values = list(string)<br/>  }))</pre> | `[]` | no |
 | <a name="input_registry_scan_type"></a> [registry\_scan\_type](#input\_registry\_scan\_type) | The type of scanning to configure for the registry. Either BASIC or ENHANCED. | `string` | `"ENHANCED"` | no |
 | <a name="input_replication_regions"></a> [replication\_regions](#input\_replication\_regions) | List of AWS regions to replicate ECR images to. | `list(string)` | `[]` | no |
+| <a name="input_repository_creation_templates"></a> [repository\_creation\_templates](#input\_repository\_creation\_templates) | List of ECR repository creation templates to create. Templates apply only to repositories Amazon ECR creates through pull-through cache, create-on-push, or replication actions. The resource\_tags field controls tags ECR applies to repositories created from the template and does not inherit the module-level tags variable. | <pre>list(object({<br/>    prefix          = string<br/>    applied_for     = list(string)<br/>    custom_role_arn = optional(string)<br/>    description     = optional(string)<br/>    encryption_configuration = optional(object({<br/>      encryption_type = optional(string, "AES256")<br/>      kms_key         = optional(string)<br/>    }))<br/>    image_tag_mutability = optional(string, "MUTABLE")<br/>    lifecycle_policy     = optional(string)<br/>    repository_policy    = optional(string)<br/>    resource_tags        = optional(map(string), {})<br/>  }))</pre> | `[]` | no |
 | <a name="input_required_tags"></a> [required\_tags](#input\_required\_tags) | List of tag keys that are required to be present. Empty list disables validation. | `list(string)` | `[]` | no |
 | <a name="input_scan_on_push"></a> [scan\_on\_push](#input\_scan\_on\_push) | Whether images should be scanned after being pushed to the repository. | `bool` | `true` | no |
 | <a name="input_scan_repository_filters"></a> [scan\_repository\_filters](#input\_scan\_repository\_filters) | List of repository filters to apply for registry scanning. Supports wildcards. | `list(string)` | <pre>[<br/>  "*"<br/>]</pre> | no |
@@ -1992,6 +2000,8 @@ For more details on the discovery system architecture, see `.github/scripts/disc
 | <a name="output_replication_regions"></a> [replication\_regions](#output\_replication\_regions) | List of regions where ECR images are replicated to (if replication is enabled) |
 | <a name="output_replication_status"></a> [replication\_status](#output\_replication\_status) | Status of ECR replication configuration |
 | <a name="output_repository_arn"></a> [repository\_arn](#output\_repository\_arn) | ARN of the ECR repository |
+| <a name="output_repository_creation_template_status"></a> [repository\_creation\_template\_status](#output\_repository\_creation\_template\_status) | Status of ECR repository creation template configuration |
+| <a name="output_repository_creation_templates"></a> [repository\_creation\_templates](#output\_repository\_creation\_templates) | Map of ECR repository creation templates keyed by prefix |
 | <a name="output_repository_name"></a> [repository\_name](#output\_repository\_name) | Name of the ECR repository |
 | <a name="output_repository_policy_exists"></a> [repository\_policy\_exists](#output\_repository\_policy\_exists) | Whether a repository policy exists for this ECR repository |
 | <a name="output_repository_url"></a> [repository\_url](#output\_repository\_url) | URL of the ECR repository |

--- a/examples/repository-creation-template/README.md
+++ b/examples/repository-creation-template/README.md
@@ -1,0 +1,57 @@
+# ECR Repository Creation Template Example
+
+This example shows how to configure repository creation templates for repositories that Amazon ECR creates on your behalf through pull-through cache, create-on-push, or replication workflows.
+
+Repository creation templates apply only at repository creation time. They do not update existing repositories.
+
+## What this example creates
+
+- An ECR repository managed by the root module
+- Pull-through cache rules for Docker Hub and Amazon ECR Public
+- A pull-through cache repository creation template for the `docker-hub` prefix
+- A default `ROOT` repository creation template for create-on-push and replication-created repositories
+
+## Usage
+
+```bash
+terraform init
+terraform plan
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.81.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_ecr_with_repository_creation_templates"></a> [ecr\_with\_repository\_creation\_templates](#module\_ecr\_with\_repository\_creation\_templates) | ../../ | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name for tagging | `string` | `"example"` | no |
+| <a name="input_repository_name"></a> [repository\_name](#input\_repository\_name) | The name of the ECR repository | `string` | `"repository-template-example"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_pull_through_cache_rules"></a> [pull\_through\_cache\_rules](#output\_pull\_through\_cache\_rules) | Configured pull-through cache rules |
+| <a name="output_repository_creation_template_status"></a> [repository\_creation\_template\_status](#output\_repository\_creation\_template\_status) | Status of ECR repository creation template configuration |
+| <a name="output_repository_creation_templates"></a> [repository\_creation\_templates](#output\_repository\_creation\_templates) | Map of ECR repository creation templates keyed by prefix |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/repository-creation-template/main.tf
+++ b/examples/repository-creation-template/main.tf
@@ -1,0 +1,70 @@
+# ----------------------------------------------------------
+# Repository Creation Template Example Configuration
+# ----------------------------------------------------------
+
+module "ecr_with_repository_creation_templates" {
+  source = "../../"
+
+  name = var.repository_name
+
+  # Configure pull-through cache rules. Repository creation templates below
+  # control settings for repositories ECR creates from these prefixes.
+  enable_pull_through_cache = true
+  pull_through_cache_rules = [
+    {
+      ecr_repository_prefix = "docker-hub"
+      upstream_registry_url = "registry-1.docker.io"
+    },
+    {
+      ecr_repository_prefix = "public-ecr"
+      upstream_registry_url = "public.ecr.aws"
+    }
+  ]
+
+  enable_repository_creation_templates = true
+  repository_creation_templates = [
+    {
+      prefix      = "docker-hub"
+      description = "Template for repositories created by the Docker Hub pull-through cache rule"
+      applied_for = ["PULL_THROUGH_CACHE"]
+
+      # AWS recommends MUTABLE for pull-through cache templates so ECR can
+      # refresh cached tags when upstream images change.
+      image_tag_mutability = "MUTABLE"
+
+      encryption_configuration = {
+        encryption_type = "AES256"
+      }
+
+      lifecycle_policy = jsonencode({
+        rules = [
+          {
+            rulePriority = 1
+            description  = "Expire untagged cached images after 7 days"
+            selection = {
+              tagStatus   = "untagged"
+              countType   = "sinceImagePushed"
+              countUnit   = "days"
+              countNumber = 7
+            }
+            action = {
+              type = "expire"
+            }
+          }
+        ]
+      })
+    },
+    {
+      prefix               = "ROOT"
+      description          = "Default template for repositories ECR creates by replication or create-on-push"
+      applied_for          = ["CREATE_ON_PUSH", "REPLICATION"]
+      image_tag_mutability = "IMMUTABLE"
+    }
+  ]
+
+  tags = {
+    Name        = var.repository_name
+    Environment = var.environment
+    Example     = "repository-creation-template"
+  }
+}

--- a/examples/repository-creation-template/outputs.tf
+++ b/examples/repository-creation-template/outputs.tf
@@ -1,0 +1,14 @@
+output "repository_creation_templates" {
+  description = "Map of ECR repository creation templates keyed by prefix"
+  value       = module.ecr_with_repository_creation_templates.repository_creation_templates
+}
+
+output "repository_creation_template_status" {
+  description = "Status of ECR repository creation template configuration"
+  value       = module.ecr_with_repository_creation_templates.repository_creation_template_status
+}
+
+output "pull_through_cache_rules" {
+  description = "Configured pull-through cache rules"
+  value       = module.ecr_with_repository_creation_templates.pull_through_cache_rules
+}

--- a/examples/repository-creation-template/variables.tf
+++ b/examples/repository-creation-template/variables.tf
@@ -1,0 +1,11 @@
+variable "repository_name" {
+  description = "The name of the ECR repository"
+  type        = string
+  default     = "repository-template-example"
+}
+
+variable "environment" {
+  description = "Environment name for tagging"
+  type        = string
+  default     = "example"
+}

--- a/examples/repository-creation-template/versions.tf
+++ b/examples/repository-creation-template/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.81.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}

--- a/main.tf
+++ b/main.tf
@@ -36,6 +36,10 @@ locals {
   pull_through_cache_modules = var.enable_pull_through_cache && length(var.pull_through_cache_rules) > 0 ? {
     cache = {}
   } : {}
+
+  repository_creation_templates = var.enable_repository_creation_templates ? {
+    for template in var.repository_creation_templates : template.prefix => template
+  } : {}
 }
 
 # KMS key submodule
@@ -259,4 +263,32 @@ module "pull_through_cache" {
     aws_ecr_repository.repo,
     aws_ecr_repository.repo_protected
   ]
+}
+
+# ----------------------------------------------------------
+# Repository Creation Templates
+# ----------------------------------------------------------
+
+# Templates for repositories Amazon ECR creates through pull-through cache,
+# create-on-push, or replication workflows.
+resource "aws_ecr_repository_creation_template" "this" {
+  for_each = local.repository_creation_templates
+
+  prefix               = each.value.prefix
+  applied_for          = each.value.applied_for
+  custom_role_arn      = each.value.custom_role_arn
+  description          = each.value.description
+  image_tag_mutability = each.value.image_tag_mutability
+  lifecycle_policy     = each.value.lifecycle_policy
+  repository_policy    = each.value.repository_policy
+  resource_tags        = each.value.resource_tags
+
+  dynamic "encryption_configuration" {
+    for_each = each.value.encryption_configuration == null ? [] : [each.value.encryption_configuration]
+    content {
+      encryption_type = encryption_configuration.value.encryption_type
+      kms_key         = encryption_configuration.value.kms_key
+    }
+  }
+
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -120,6 +120,26 @@ output "pull_through_cache_role_arn" {
   value       = var.enable_pull_through_cache && length(var.pull_through_cache_rules) > 0 ? try(module.pull_through_cache["cache"].pull_through_cache_role_arn, null) : null
 }
 
+output "repository_creation_templates" {
+  description = "Map of ECR repository creation templates keyed by prefix"
+  value = {
+    for prefix, template in aws_ecr_repository_creation_template.this : prefix => {
+      prefix               = template.prefix
+      registry_id          = template.registry_id
+      applied_for          = template.applied_for
+      image_tag_mutability = template.image_tag_mutability
+    }
+  }
+}
+
+output "repository_creation_template_status" {
+  description = "Status of ECR repository creation template configuration"
+  value = {
+    enabled  = var.enable_repository_creation_templates
+    prefixes = var.enable_repository_creation_templates ? keys(local.repository_creation_templates) : []
+  }
+}
+
 output "registry_scan_filters" {
   description = "The configured scan filters for filtering scan results (e.g., by vulnerability severity)"
   value       = var.registry_scan_filters
@@ -128,15 +148,16 @@ output "registry_scan_filters" {
 output "security_status" {
   description = "Comprehensive security status of the ECR configuration"
   value = {
-    basic_scanning_enabled     = local.image_scanning_configuration[0].scan_on_push
-    enhanced_scanning_enabled  = var.enable_registry_scanning
-    secret_scanning_enabled    = var.enable_secret_scanning
-    pull_through_cache_enabled = var.enable_pull_through_cache
-    encryption_type            = var.encryption_type
-    kms_encryption_enabled     = var.encryption_type == "KMS"
-    image_tag_mutability       = var.image_tag_mutability
-    replication_enabled        = var.enable_replication
-    scan_filters_configured    = length(var.registry_scan_filters) > 0
+    basic_scanning_enabled       = local.image_scanning_configuration[0].scan_on_push
+    enhanced_scanning_enabled    = var.enable_registry_scanning
+    secret_scanning_enabled      = var.enable_secret_scanning
+    pull_through_cache_enabled   = var.enable_pull_through_cache
+    repository_templates_enabled = var.enable_repository_creation_templates
+    encryption_type              = var.encryption_type
+    kms_encryption_enabled       = var.encryption_type == "KMS"
+    image_tag_mutability         = var.image_tag_mutability
+    replication_enabled          = var.enable_replication
+    scan_filters_configured      = length(var.registry_scan_filters) > 0
   }
 }
 

--- a/test/fixtures/repository-creation-template/main.tf
+++ b/test/fixtures/repository-creation-template/main.tf
@@ -1,0 +1,59 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.81.0"
+    }
+  }
+}
+
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  skip_metadata_api_check     = true
+}
+
+module "repository_creation_template" {
+  source = "../../../"
+
+  name = "fixture-repository-creation-template"
+
+  enable_repository_creation_templates = true
+  repository_creation_templates = [
+    {
+      prefix               = "ROOT"
+      description          = "Default template for ECR-created repositories"
+      applied_for          = ["CREATE_ON_PUSH", "REPLICATION"]
+      image_tag_mutability = "IMMUTABLE"
+      encryption_configuration = {
+        encryption_type = "AES256"
+      }
+    },
+    {
+      prefix               = "docker-hub"
+      description          = "Template for pull-through cache repositories"
+      applied_for          = ["PULL_THROUGH_CACHE"]
+      image_tag_mutability = "MUTABLE"
+      lifecycle_policy = jsonencode({
+        rules = [
+          {
+            rulePriority = 1
+            description  = "Expire untagged cached images after 7 days"
+            selection = {
+              tagStatus   = "untagged"
+              countType   = "sinceImagePushed"
+              countUnit   = "days"
+              countNumber = 7
+            }
+            action = {
+              type = "expire"
+            }
+          }
+        ]
+      })
+    }
+  ]
+}

--- a/test/fixtures/repository-creation-template/outputs.tf
+++ b/test/fixtures/repository-creation-template/outputs.tf
@@ -1,0 +1,9 @@
+output "repository_creation_template_status" {
+  description = "Status of ECR repository creation template configuration"
+  value       = module.repository_creation_template.repository_creation_template_status
+}
+
+output "repository_creation_templates" {
+  description = "Map of ECR repository creation templates keyed by prefix"
+  value       = module.repository_creation_template.repository_creation_templates
+}

--- a/variables.tf
+++ b/variables.tf
@@ -501,6 +501,89 @@ variable "pull_through_cache_rules" {
 }
 
 # ----------------------------------------------------------
+# Repository Creation Template Configuration
+# ----------------------------------------------------------
+
+variable "enable_repository_creation_templates" {
+  description = "Whether to create ECR repository creation templates for repositories created by pull-through cache, create-on-push, or replication actions."
+  type        = bool
+  default     = false
+}
+
+variable "repository_creation_templates" {
+  description = "List of ECR repository creation templates to create. Templates apply only to repositories Amazon ECR creates through pull-through cache, create-on-push, or replication actions. The resource_tags field controls tags ECR applies to repositories created from the template and does not inherit the module-level tags variable."
+  type = list(object({
+    prefix          = string
+    applied_for     = list(string)
+    custom_role_arn = optional(string)
+    description     = optional(string)
+    encryption_configuration = optional(object({
+      encryption_type = optional(string, "AES256")
+      kms_key         = optional(string)
+    }))
+    image_tag_mutability = optional(string, "MUTABLE")
+    lifecycle_policy     = optional(string)
+    repository_policy    = optional(string)
+    resource_tags        = optional(map(string), {})
+  }))
+  default = []
+
+  validation {
+    condition = length(var.repository_creation_templates) == length(distinct([
+      for template in var.repository_creation_templates : template.prefix
+    ]))
+    error_message = "Each repository creation template prefix must be unique."
+  }
+
+  validation {
+    condition = alltrue([
+      for template in var.repository_creation_templates :
+      template.prefix == "ROOT" || can(regex("^[a-z0-9]+(?:[._/-][a-z0-9]+)*$", template.prefix))
+    ])
+    error_message = "Each repository creation template prefix must be ROOT or a valid ECR repository namespace prefix."
+  }
+
+  validation {
+    condition = alltrue([
+      for template in var.repository_creation_templates :
+      length(template.applied_for) > 0 && alltrue([
+        for applied_for in template.applied_for : contains(["CREATE_ON_PUSH", "PULL_THROUGH_CACHE", "REPLICATION"], applied_for)
+      ])
+    ])
+    error_message = "Each repository creation template applied_for list must contain one or more of CREATE_ON_PUSH, PULL_THROUGH_CACHE, or REPLICATION."
+  }
+
+  validation {
+    condition = alltrue([
+      for template in var.repository_creation_templates :
+      contains(["MUTABLE", "IMMUTABLE"], template.image_tag_mutability)
+    ])
+    error_message = "Repository creation template image_tag_mutability must be one of MUTABLE or IMMUTABLE."
+  }
+
+  validation {
+    condition = alltrue([
+      for template in var.repository_creation_templates :
+      try(contains(["AES256", "KMS"], template.encryption_configuration.encryption_type), true)
+    ])
+    error_message = "Repository creation template encryption_type must be AES256 or KMS."
+  }
+
+  validation {
+    condition = alltrue([
+      for template in var.repository_creation_templates :
+      !(
+        (
+          length(template.resource_tags) > 0 ||
+          try(template.encryption_configuration.encryption_type == "KMS", false)
+        ) && template.custom_role_arn == null
+      )
+    ])
+    error_message = "Repository creation templates that use resource_tags or KMS encryption must set custom_role_arn."
+  }
+}
+
+# ----------------------------------------------------------
 # Secret Scanning Configuration
 # ----------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add optional `aws_ecr_repository_creation_template` support for ECR-created repositories
- Add a repository creation template example and validation fixture
- Expose template status and template metadata outputs

## Notes
Repository creation templates apply to repositories Amazon ECR creates through pull-through cache, create-on-push, or replication workflows. This PR keeps the AWS provider floor at `>= 5.81.0`, so it intentionally does not expose newer template image-tag mutability exclusion filter blocks that are unavailable in older `~> 5.0` fixture/provider locks.
