### PR TITLE
fix: release refactor commits as patch updates

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -4,7 +4,25 @@
       "release-type": "terraform-module",
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": false,
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance Improvements"
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactoring"
+        }
+      ]
     }
   },
   "pull-request-title-pattern": "chore: release ${version}"

--- a/README.md
+++ b/README.md
@@ -1556,7 +1556,7 @@ For more details on the Terraform fixtures, see the [test directory README](test
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 
@@ -1863,7 +1863,7 @@ For more details on the discovery system architecture, see `.github/scripts/disc
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -60,7 +60,11 @@ This module uses [Release Please](https://github.com/googleapis/release-please) 
    - `feat!:` or `fix!:` or any type with `!` for breaking changes (MAJOR version bump)
    - `docs:` for documentation updates (no version bump)
    - `chore:` for maintenance tasks (no version bump)
-   - `refactor:` for code refactoring (PATCH version bump if behavior might be affected)
+   - `refactor:` for Terraform module implementation refactors (PATCH version bump when no `feat` or breaking change is present)
+
+   Release Please is configured to include `refactor:` commits in the changelog under **Code Refactoring**. Use `refactor:` for changes to module `.tf` implementation, locals, defaults, validations, dynamic block emission, provider compatibility, or resource construction that should ship to pinned module users without mislabeling them as bug fixes.
+
+   Documentation-only and CI-only commits should continue to use `docs:` or `ci:` and do not publish a release by default.
 
 2. When commits are pushed to the main branch, Release Please:
    - Analyzes commit messages since the last release

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -337,7 +337,7 @@ This example serves as a comprehensive reference for production-ready ECR deploy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/examples/enhanced-kms/README.md
+++ b/examples/enhanced-kms/README.md
@@ -223,7 +223,7 @@ kms_tags = {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/examples/monitoring/README.md
+++ b/examples/monitoring/README.md
@@ -144,7 +144,7 @@ aws ecr describe-repositories --repository-names my-app
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/examples/multi-region/README.md
+++ b/examples/multi-region/README.md
@@ -137,7 +137,7 @@ Note: You must delete all images from the repositories before they can be delete
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.primary"></a> [aws.primary](#provider\_aws.primary) | 6.49.0 |
+| <a name="provider_aws.primary"></a> [aws.primary](#provider\_aws.primary) | 6.50.0 |
 
 ## Modules
 

--- a/examples/protected/README.md
+++ b/examples/protected/README.md
@@ -118,7 +118,7 @@ Remember: Both protection mechanisms must be removed in this order:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/examples/pull-request-rules/README.md
+++ b/examples/pull-request-rules/README.md
@@ -114,7 +114,7 @@ The example can be customized by:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/examples/pull-through-cache/README.md
+++ b/examples/pull-through-cache/README.md
@@ -131,7 +131,7 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/examples/with-ecs-integration/README.md
+++ b/examples/with-ecs-integration/README.md
@@ -101,7 +101,7 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/modules/kms/README.md
+++ b/modules/kms/README.md
@@ -196,7 +196,7 @@ See the `examples/` directory for complete usage examples.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/modules/pull-through-cache/README.md
+++ b/modules/pull-through-cache/README.md
@@ -90,7 +90,7 @@ module "pull_through_cache" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 


### PR DESCRIPTION
## Summary
- Configure release-please to include `refactor:` commits under a Code Refactoring changelog section.
- Document that Terraform module implementation refactors should use `refactor:` and publish patch releases for pinned users.
- Refresh generated terraform-docs output so the all-files pre-commit gate remains clean.

Closes #192

## Notes
Release Please default versioning bumps patch when there are releasable commits without `feat` or breaking changes. Including `refactor` in changelog sections makes implementation refactors user-facing/releasable without changing existing `feat:` and `fix:` behavior.