### PR TITLE
fix: replace deprecated aws_region.current.id/name with .region

### DIFF
--- a/examples/pull-request-rules/outputs.tf
+++ b/examples/pull-request-rules/outputs.tf
@@ -30,7 +30,7 @@ output "approval_role_arn" {
 output "example_docker_commands" {
   description = "Example Docker commands for working with the repository"
   value = {
-    login = "aws ecr get-login-password --region ${data.aws_region.current.id} | docker login --username AWS --password-stdin ${module.ecr_with_pr_rules.repository_url}"
+    login = "aws ecr get-login-password --region ${data.aws_region.current.region} | docker login --username AWS --password-stdin ${module.ecr_with_pr_rules.repository_url}"
     build = "docker build -t ${module.ecr_with_pr_rules.repository_name}:latest ."
     tag   = "docker tag ${module.ecr_with_pr_rules.repository_name}:latest ${module.ecr_with_pr_rules.repository_url}:latest"
     push  = "docker push ${module.ecr_with_pr_rules.repository_url}:latest"

--- a/examples/pull-through-cache/outputs.tf
+++ b/examples/pull-through-cache/outputs.tf
@@ -34,10 +34,10 @@ output "registry_id" {
 output "docker_pull_examples" {
   description = "Example docker pull commands using the configured cache rules"
   value = {
-    docker_hub = "docker pull ${module.ecr_with_pull_through_cache.registry_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/docker-hub/library/nginx:latest"
-    quay       = "docker pull ${module.ecr_with_pull_through_cache.registry_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/quay/prometheus/prometheus:latest"
-    ghcr       = "docker pull ${module.ecr_with_pull_through_cache.registry_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/ghcr/actions/runner:latest"
-    public_ecr = "docker pull ${module.ecr_with_pull_through_cache.registry_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/public-ecr/amazonlinux:latest"
+    docker_hub = "docker pull ${module.ecr_with_pull_through_cache.registry_id}.dkr.ecr.${data.aws_region.current.region}.amazonaws.com/docker-hub/library/nginx:latest"
+    quay       = "docker pull ${module.ecr_with_pull_through_cache.registry_id}.dkr.ecr.${data.aws_region.current.region}.amazonaws.com/quay/prometheus/prometheus:latest"
+    ghcr       = "docker pull ${module.ecr_with_pull_through_cache.registry_id}.dkr.ecr.${data.aws_region.current.region}.amazonaws.com/ghcr/actions/runner:latest"
+    public_ecr = "docker pull ${module.ecr_with_pull_through_cache.registry_id}.dkr.ecr.${data.aws_region.current.region}.amazonaws.com/public-ecr/amazonlinux:latest"
   }
 }
 

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -24,7 +24,7 @@ locals {
   # Updated SNS topic ARN local
   sns_topic_arn = var.enable_monitoring ? (
     var.create_sns_topic ? try(aws_sns_topic.ecr_monitoring["ecr_monitoring"].arn, null) :
-    (var.sns_topic_name != null ? "arn:aws:sns:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:${var.sns_topic_name}" : null)
+    (var.sns_topic_name != null ? "arn:aws:sns:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:${var.sns_topic_name}" : null)
   ) : null
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -6,9 +6,10 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      # Require AWS provider 5.81.0+ for ECR account settings support
-      # (aws_ecr_account_setting resource introduced in 5.81.0)
-      version = ">= 5.81.0"
+      # Require AWS provider 6.0.0+ for the `region` attribute on the
+      # aws_region data source (which replaced the now-deprecated `id`/`name`).
+      # 6.0.0 also retains ECR account settings support added in 5.81.0.
+      version = ">= 6.0.0"
     }
     archive = {
       source  = "hashicorp/archive"


### PR DESCRIPTION
## What

AWS provider **v6.0** deprecated `id` and `name` on the `aws_region` data source in favour of `region`. With provider 6.x, the module emits a deprecation warning on every `plan`/`apply`:

```
Warning: Deprecated value used
  on monitoring.tf line 27, in locals:
  ...arn:aws:sns:${data.aws_region.current.id}:...
  Use 'region' instead. This attribute will be removed in a future version of the provider.
```

Because the module's `monitoring.tf` is instantiated once per consumer module call, this multiplies across a config (we hit 24 of these from 8 ECR module instances).

## Changes

- `monitoring.tf` — SNS topic ARN now uses `data.aws_region.current.region`
- `examples/pull-request-rules/outputs.tf` — `.id` → `.region`
- `examples/pull-through-cache/outputs.tf` — `.name` → `.region` (×4)
- `versions.tf` — bump the AWS provider floor `>= 5.81.0` → `>= 6.0.0`

## Compatibility note (please review)

The `region` attribute only exists on the `aws_region` data source in **AWS provider v6.0+**, so this necessarily raises the provider floor — hence the `BREAKING CHANGE` footer. There's no single attribute that is non-deprecated on 5.x *and* present on 6.x, so a backward-compatible fix isn't really possible without a `try()` shim. Flagging in case you'd prefer to gate the version bump to a major release.

Happy to adjust the commit type / scope to match your release-please flow.