### PR TITLE
fix: align examples with AWS provider v6 floor

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ module "ecr" {
 - `account_setting` - Account setting configuration status and values for both settings
 
 **Important Notes:**
-- Requires AWS Provider >= 5.81.0 for `aws_ecr_account_setting` resource
+- Requires AWS Provider >= 6.0.0 for `data.aws_region.current.region` support and `aws_ecr_account_setting` resource support
 - AWS Native scanning provides improved performance and accuracy
 - CLAIR-based scanning will be deprecated on February 2, 2026
 - Registry Policy Scope V2 is the default for new registries and provides granular control over all ECR actions
@@ -1549,14 +1549,14 @@ For more details on the Terraform fixtures, see the [test directory README](test
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.81.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 
@@ -1856,14 +1856,14 @@ For more details on the discovery system architecture, see `.github/scripts/disc
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.81.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/examples/advanced-tagging/README.md
+++ b/examples/advanced-tagging/README.md
@@ -223,7 +223,7 @@ Run `terraform output` to see all available outputs and their current values.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 

--- a/examples/advanced-tagging/main.tf
+++ b/examples/advanced-tagging/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -331,13 +331,13 @@ This example serves as a comprehensive reference for production-ready ECR deploy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/examples/enhanced-kms/README.md
+++ b/examples/enhanced-kms/README.md
@@ -217,13 +217,13 @@ kms_tags = {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/examples/enhanced-kms/main.tf
+++ b/examples/enhanced-kms/main.tf
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/examples/enhanced-security/README.md
+++ b/examples/enhanced-security/README.md
@@ -114,13 +114,13 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/examples/enhanced-security/versions.tf
+++ b/examples/enhanced-security/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 6.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/examples/lifecycle-policies/README.md
+++ b/examples/lifecycle-policies/README.md
@@ -411,7 +411,7 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 

--- a/examples/lifecycle-policies/main.tf
+++ b/examples/lifecycle-policies/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/examples/monitoring/README.md
+++ b/examples/monitoring/README.md
@@ -138,13 +138,13 @@ aws ecr describe-repositories --repository-names my-app
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/examples/monitoring/main.tf
+++ b/examples/monitoring/main.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 6.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/examples/multi-region/README.md
+++ b/examples/multi-region/README.md
@@ -131,13 +131,13 @@ Note: You must delete all images from the repositories before they can be delete
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.primary"></a> [aws.primary](#provider\_aws.primary) | 6.50.0 |
+| <a name="provider_aws.primary"></a> [aws.primary](#provider\_aws.primary) | 6.51.0 |
 
 ## Modules
 

--- a/examples/multi-region/versions.tf
+++ b/examples/multi-region/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/examples/protected/README.md
+++ b/examples/protected/README.md
@@ -112,13 +112,13 @@ Remember: Both protection mechanisms must be removed in this order:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/examples/protected/versions.tf
+++ b/examples/protected/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/examples/pull-request-rules/README.md
+++ b/examples/pull-request-rules/README.md
@@ -108,13 +108,13 @@ The example can be customized by:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/examples/pull-request-rules/versions.tf
+++ b/examples/pull-request-rules/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/examples/pull-through-cache/README.md
+++ b/examples/pull-through-cache/README.md
@@ -125,13 +125,13 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/examples/pull-through-cache/versions.tf
+++ b/examples/pull-through-cache/versions.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/examples/replication/README.md
+++ b/examples/replication/README.md
@@ -112,7 +112,7 @@ Note: If repositories contain images, you may need to set `force_delete = true` 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 

--- a/examples/replication/main.tf
+++ b/examples/replication/main.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/examples/repository-creation-template/README.md
+++ b/examples/repository-creation-template/README.md
@@ -24,7 +24,7 @@ terraform plan
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.81.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 

--- a/examples/repository-creation-template/versions.tf
+++ b/examples/repository-creation-template/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.81.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -147,7 +147,7 @@ After trying this simple example, you might want to explore:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/examples/with-ecs-integration/README.md
+++ b/examples/with-ecs-integration/README.md
@@ -95,13 +95,13 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/examples/with-ecs-integration/versions.tf
+++ b/examples/with-ecs-integration/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/modules/kms/README.md
+++ b/modules/kms/README.md
@@ -190,13 +190,13 @@ See the `examples/` directory for complete usage examples.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/modules/kms/versions.tf
+++ b/modules/kms/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/modules/pull-through-cache/README.md
+++ b/modules/pull-through-cache/README.md
@@ -84,13 +84,13 @@ module "pull_through_cache" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/modules/pull-through-cache/versions.tf
+++ b/modules/pull-through-cache/versions.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/test/fixtures/advanced-tagging/versions.tf
+++ b/test/fixtures/advanced-tagging/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/test/fixtures/basic/versions.tf
+++ b/test/fixtures/basic/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/test/fixtures/complete/versions.tf
+++ b/test/fixtures/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/test/fixtures/enhanced-security/versions.tf
+++ b/test/fixtures/enhanced-security/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 6.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/test/fixtures/lifecycle-policies-helper-vars/main.tf
+++ b/test/fixtures/lifecycle-policies-helper-vars/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 6.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/test/fixtures/lifecycle-policies-templates/main.tf
+++ b/test/fixtures/lifecycle-policies-templates/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 6.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/test/fixtures/lifecycle-policies/main.tf
+++ b/test/fixtures/lifecycle-policies/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/test/fixtures/monitoring/main.tf
+++ b/test/fixtures/monitoring/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 6.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/test/fixtures/repository-creation-template/main.tf
+++ b/test/fixtures/repository-creation-template/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.81.0"
+      version = ">= 6.0.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Align examples, validation fixtures, and submodule AWS provider constraints with the new root `>= 6.0.0` floor
- Refresh generated terraform-docs output after the provider floor change
- Fixes the post-merge `master` pre-commit failure caused by conflicting `~> 5.0` and `>= 6.0.0` constraints

## Validation
- `terraform fmt -check -recursive`
- `git diff --check`
- initialized root, submodules, examples, and test fixtures with `terraform init -backend=false -input=false`
- `pre-commit run terraform_docs --all-files`
- `PRE_COMMIT_HOME="$PWD/.cache/pre-commit" pre-commit run --all-files`

Follow-up to #199; unblocks release PR #200.
