### PR TITLE
feat: add image tag mutability exclusion filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1549,14 +1549,14 @@ For more details on the Terraform fixtures, see the [test directory README](test
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.50.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 
@@ -1622,6 +1622,7 @@ For more details on the Terraform fixtures, see the [test directory README](test
 | <a name="input_force_delete"></a> [force\_delete](#input\_force\_delete) | Whether to delete the repository even if it contains images. Use with caution. | `bool` | `false` | no |
 | <a name="input_image_scanning_configuration"></a> [image\_scanning\_configuration](#input\_image\_scanning\_configuration) | Image scanning configuration block. Set to null to use scan\_on\_push variable. | <pre>object({<br/>    scan_on_push = bool<br/>  })</pre> | `null` | no |
 | <a name="input_image_tag_mutability"></a> [image\_tag\_mutability](#input\_image\_tag\_mutability) | The tag mutability setting for the repository. Either MUTABLE, IMMUTABLE, IMMUTABLE\_WITH\_EXCLUSION, or MUTABLE\_WITH\_EXCLUSION. | `string` | `"MUTABLE"` | no |
+| <a name="input_image_tag_mutability_exclusion_filters"></a> [image\_tag\_mutability\_exclusion\_filters](#input\_image\_tag\_mutability\_exclusion\_filters) | List of image tag mutability exclusion filters. Use only when image\_tag\_mutability is IMMUTABLE\_WITH\_EXCLUSION or MUTABLE\_WITH\_EXCLUSION. | <pre>list(object({<br/>    filter      = string<br/>    filter_type = optional(string, "WILDCARD")<br/>  }))</pre> | `[]` | no |
 | <a name="input_kms_additional_principals"></a> [kms\_additional\_principals](#input\_kms\_additional\_principals) | List of additional IAM principals (ARNs) to grant KMS key access. | `list(string)` | `[]` | no |
 | <a name="input_kms_alias_name"></a> [kms\_alias\_name](#input\_kms\_alias\_name) | Custom alias name for the KMS key (without 'alias/' prefix). | `string` | `null` | no |
 | <a name="input_kms_custom_policy"></a> [kms\_custom\_policy](#input\_kms\_custom\_policy) | Complete custom policy JSON for the KMS key. Use with caution. | `string` | `null` | no |
@@ -1657,7 +1658,7 @@ For more details on the Terraform fixtures, see the [test directory README](test
 | <a name="input_registry_scan_filters"></a> [registry\_scan\_filters](#input\_registry\_scan\_filters) | List of scan filters for filtering scan results when querying ECR findings. | <pre>list(object({<br/>    name   = string<br/>    values = list(string)<br/>  }))</pre> | `[]` | no |
 | <a name="input_registry_scan_type"></a> [registry\_scan\_type](#input\_registry\_scan\_type) | The type of scanning to configure for the registry. Either BASIC or ENHANCED. | `string` | `"ENHANCED"` | no |
 | <a name="input_replication_regions"></a> [replication\_regions](#input\_replication\_regions) | List of AWS regions to replicate ECR images to. | `list(string)` | `[]` | no |
-| <a name="input_repository_creation_templates"></a> [repository\_creation\_templates](#input\_repository\_creation\_templates) | List of ECR repository creation templates to create. Templates apply only to repositories Amazon ECR creates through pull-through cache, create-on-push, or replication actions. The resource\_tags field controls tags ECR applies to repositories created from the template and does not inherit the module-level tags variable. | <pre>list(object({<br/>    prefix          = string<br/>    applied_for     = list(string)<br/>    custom_role_arn = optional(string)<br/>    description     = optional(string)<br/>    encryption_configuration = optional(object({<br/>      encryption_type = optional(string, "AES256")<br/>      kms_key         = optional(string)<br/>    }))<br/>    image_tag_mutability = optional(string, "MUTABLE")<br/>    lifecycle_policy     = optional(string)<br/>    repository_policy    = optional(string)<br/>    resource_tags        = optional(map(string), {})<br/>  }))</pre> | `[]` | no |
+| <a name="input_repository_creation_templates"></a> [repository\_creation\_templates](#input\_repository\_creation\_templates) | List of ECR repository creation templates to create. Templates apply only to repositories Amazon ECR creates through pull-through cache, create-on-push, or replication actions. The resource\_tags field controls tags ECR applies to repositories created from the template and does not inherit the module-level tags variable. | <pre>list(object({<br/>    prefix          = string<br/>    applied_for     = list(string)<br/>    custom_role_arn = optional(string)<br/>    description     = optional(string)<br/>    encryption_configuration = optional(object({<br/>      encryption_type = optional(string, "AES256")<br/>      kms_key         = optional(string)<br/>    }))<br/>    image_tag_mutability = optional(string, "MUTABLE")<br/>    image_tag_mutability_exclusion_filters = optional(list(object({<br/>      filter      = string<br/>      filter_type = optional(string, "WILDCARD")<br/>    })), [])<br/>    lifecycle_policy  = optional(string)<br/>    repository_policy = optional(string)<br/>    resource_tags     = optional(map(string), {})<br/>  }))</pre> | `[]` | no |
 | <a name="input_required_tags"></a> [required\_tags](#input\_required\_tags) | List of tag keys that are required to be present. Empty list disables validation. | `list(string)` | `[]` | no |
 | <a name="input_scan_on_push"></a> [scan\_on\_push](#input\_scan\_on\_push) | Whether images should be scanned after being pushed to the repository. | `bool` | `true` | no |
 | <a name="input_scan_repository_filters"></a> [scan\_repository\_filters](#input\_scan\_repository\_filters) | List of repository filters to apply for registry scanning. Supports wildcards. | `list(string)` | <pre>[<br/>  "*"<br/>]</pre> | no |
@@ -1856,14 +1857,14 @@ For more details on the discovery system architecture, see `.github/scripts/disc
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.50.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 
@@ -1929,6 +1930,7 @@ For more details on the discovery system architecture, see `.github/scripts/disc
 | <a name="input_force_delete"></a> [force\_delete](#input\_force\_delete) | Whether to delete the repository even if it contains images. Use with caution. | `bool` | `false` | no |
 | <a name="input_image_scanning_configuration"></a> [image\_scanning\_configuration](#input\_image\_scanning\_configuration) | Image scanning configuration block. Set to null to use scan\_on\_push variable. | <pre>object({<br/>    scan_on_push = bool<br/>  })</pre> | `null` | no |
 | <a name="input_image_tag_mutability"></a> [image\_tag\_mutability](#input\_image\_tag\_mutability) | The tag mutability setting for the repository. Either MUTABLE, IMMUTABLE, IMMUTABLE\_WITH\_EXCLUSION, or MUTABLE\_WITH\_EXCLUSION. | `string` | `"MUTABLE"` | no |
+| <a name="input_image_tag_mutability_exclusion_filters"></a> [image\_tag\_mutability\_exclusion\_filters](#input\_image\_tag\_mutability\_exclusion\_filters) | List of image tag mutability exclusion filters. Use only when image\_tag\_mutability is IMMUTABLE\_WITH\_EXCLUSION or MUTABLE\_WITH\_EXCLUSION. | <pre>list(object({<br/>    filter      = string<br/>    filter_type = optional(string, "WILDCARD")<br/>  }))</pre> | `[]` | no |
 | <a name="input_kms_additional_principals"></a> [kms\_additional\_principals](#input\_kms\_additional\_principals) | List of additional IAM principals (ARNs) to grant KMS key access. | `list(string)` | `[]` | no |
 | <a name="input_kms_alias_name"></a> [kms\_alias\_name](#input\_kms\_alias\_name) | Custom alias name for the KMS key (without 'alias/' prefix). | `string` | `null` | no |
 | <a name="input_kms_custom_policy"></a> [kms\_custom\_policy](#input\_kms\_custom\_policy) | Complete custom policy JSON for the KMS key. Use with caution. | `string` | `null` | no |
@@ -1964,7 +1966,7 @@ For more details on the discovery system architecture, see `.github/scripts/disc
 | <a name="input_registry_scan_filters"></a> [registry\_scan\_filters](#input\_registry\_scan\_filters) | List of scan filters for filtering scan results when querying ECR findings. | <pre>list(object({<br/>    name   = string<br/>    values = list(string)<br/>  }))</pre> | `[]` | no |
 | <a name="input_registry_scan_type"></a> [registry\_scan\_type](#input\_registry\_scan\_type) | The type of scanning to configure for the registry. Either BASIC or ENHANCED. | `string` | `"ENHANCED"` | no |
 | <a name="input_replication_regions"></a> [replication\_regions](#input\_replication\_regions) | List of AWS regions to replicate ECR images to. | `list(string)` | `[]` | no |
-| <a name="input_repository_creation_templates"></a> [repository\_creation\_templates](#input\_repository\_creation\_templates) | List of ECR repository creation templates to create. Templates apply only to repositories Amazon ECR creates through pull-through cache, create-on-push, or replication actions. The resource\_tags field controls tags ECR applies to repositories created from the template and does not inherit the module-level tags variable. | <pre>list(object({<br/>    prefix          = string<br/>    applied_for     = list(string)<br/>    custom_role_arn = optional(string)<br/>    description     = optional(string)<br/>    encryption_configuration = optional(object({<br/>      encryption_type = optional(string, "AES256")<br/>      kms_key         = optional(string)<br/>    }))<br/>    image_tag_mutability = optional(string, "MUTABLE")<br/>    lifecycle_policy     = optional(string)<br/>    repository_policy    = optional(string)<br/>    resource_tags        = optional(map(string), {})<br/>  }))</pre> | `[]` | no |
+| <a name="input_repository_creation_templates"></a> [repository\_creation\_templates](#input\_repository\_creation\_templates) | List of ECR repository creation templates to create. Templates apply only to repositories Amazon ECR creates through pull-through cache, create-on-push, or replication actions. The resource\_tags field controls tags ECR applies to repositories created from the template and does not inherit the module-level tags variable. | <pre>list(object({<br/>    prefix          = string<br/>    applied_for     = list(string)<br/>    custom_role_arn = optional(string)<br/>    description     = optional(string)<br/>    encryption_configuration = optional(object({<br/>      encryption_type = optional(string, "AES256")<br/>      kms_key         = optional(string)<br/>    }))<br/>    image_tag_mutability = optional(string, "MUTABLE")<br/>    image_tag_mutability_exclusion_filters = optional(list(object({<br/>      filter      = string<br/>      filter_type = optional(string, "WILDCARD")<br/>    })), [])<br/>    lifecycle_policy  = optional(string)<br/>    repository_policy = optional(string)<br/>    resource_tags     = optional(map(string), {})<br/>  }))</pre> | `[]` | no |
 | <a name="input_required_tags"></a> [required\_tags](#input\_required\_tags) | List of tag keys that are required to be present. Empty list disables validation. | `list(string)` | `[]` | no |
 | <a name="input_scan_on_push"></a> [scan\_on\_push](#input\_scan\_on\_push) | Whether images should be scanned after being pushed to the repository. | `bool` | `true` | no |
 | <a name="input_scan_repository_filters"></a> [scan\_repository\_filters](#input\_scan\_repository\_filters) | List of repository filters to apply for registry scanning. Supports wildcards. | `list(string)` | <pre>[<br/>  "*"<br/>]</pre> | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -331,13 +331,13 @@ This example serves as a comprehensive reference for production-ready ECR deploy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.50.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -5,7 +5,15 @@ module "ecr" {
   source = "../.."
 
   name                 = "complete-ecr-repo"
-  image_tag_mutability = "IMMUTABLE"
+  image_tag_mutability = "IMMUTABLE_WITH_EXCLUSION"
+  image_tag_mutability_exclusion_filters = [
+    {
+      filter = "latest"
+    },
+    {
+      filter = "dev-*"
+    }
+  ]
   timeouts = {
     delete = "60m"
   }
@@ -102,7 +110,12 @@ module "ecr_protected" {
   source = "../.."
 
   name                 = "protected-ecr-repo"
-  image_tag_mutability = "IMMUTABLE" # Prevent image tags from being overwritten
+  image_tag_mutability = "IMMUTABLE_WITH_EXCLUSION" # Prevent image tags from being overwritten except allowed patterns
+  image_tag_mutability_exclusion_filters = [
+    {
+      filter = "release-candidate-*"
+    }
+  ]
   timeouts = {
     delete = "60m"
   }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = ">= 6.50.0"
     }
   }
 }

--- a/examples/enhanced-kms/README.md
+++ b/examples/enhanced-kms/README.md
@@ -223,7 +223,7 @@ kms_tags = {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 

--- a/examples/enhanced-security/README.md
+++ b/examples/enhanced-security/README.md
@@ -114,13 +114,13 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.50.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 

--- a/examples/enhanced-security/versions.tf
+++ b/examples/enhanced-security/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = ">= 6.50.0"
     }
   }
   required_version = ">= 1.0"

--- a/examples/monitoring/README.md
+++ b/examples/monitoring/README.md
@@ -144,7 +144,7 @@ aws ecr describe-repositories --repository-names my-app
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 

--- a/examples/multi-region/README.md
+++ b/examples/multi-region/README.md
@@ -131,13 +131,13 @@ Note: You must delete all images from the repositories before they can be delete
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.50.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.primary"></a> [aws.primary](#provider\_aws.primary) | 6.51.0 |
+| <a name="provider_aws.primary"></a> [aws.primary](#provider\_aws.primary) | 6.53.0 |
 
 ## Modules
 

--- a/examples/multi-region/versions.tf
+++ b/examples/multi-region/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = ">= 6.50.0"
     }
   }
 }

--- a/examples/protected/README.md
+++ b/examples/protected/README.md
@@ -112,13 +112,13 @@ Remember: Both protection mechanisms must be removed in this order:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.50.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 

--- a/examples/protected/versions.tf
+++ b/examples/protected/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = ">= 6.50.0"
     }
   }
 }

--- a/examples/pull-request-rules/README.md
+++ b/examples/pull-request-rules/README.md
@@ -108,13 +108,13 @@ The example can be customized by:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.50.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 

--- a/examples/pull-request-rules/versions.tf
+++ b/examples/pull-request-rules/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = ">= 6.50.0"
     }
   }
 }

--- a/examples/pull-through-cache/README.md
+++ b/examples/pull-through-cache/README.md
@@ -125,13 +125,13 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.50.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 

--- a/examples/pull-through-cache/versions.tf
+++ b/examples/pull-through-cache/versions.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = ">= 6.50.0"
     }
   }
 }

--- a/examples/repository-creation-template/README.md
+++ b/examples/repository-creation-template/README.md
@@ -24,7 +24,7 @@ terraform plan
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.50.0 |
 
 ## Providers
 

--- a/examples/repository-creation-template/main.tf
+++ b/examples/repository-creation-template/main.tf
@@ -28,9 +28,14 @@ module "ecr_with_repository_creation_templates" {
       description = "Template for repositories created by the Docker Hub pull-through cache rule"
       applied_for = ["PULL_THROUGH_CACHE"]
 
-      # AWS recommends MUTABLE for pull-through cache templates so ECR can
-      # refresh cached tags when upstream images change.
-      image_tag_mutability = "MUTABLE"
+      # Keep cached tags mutable by default, except for release tags that
+      # should not be overwritten once ECR creates the repository.
+      image_tag_mutability = "MUTABLE_WITH_EXCLUSION"
+      image_tag_mutability_exclusion_filters = [
+        {
+          filter = "release-*"
+        }
+      ]
 
       encryption_configuration = {
         encryption_type = "AES256"
@@ -58,7 +63,12 @@ module "ecr_with_repository_creation_templates" {
       prefix               = "ROOT"
       description          = "Default template for repositories ECR creates by replication or create-on-push"
       applied_for          = ["CREATE_ON_PUSH", "REPLICATION"]
-      image_tag_mutability = "IMMUTABLE"
+      image_tag_mutability = "IMMUTABLE_WITH_EXCLUSION"
+      image_tag_mutability_exclusion_filters = [
+        {
+          filter = "latest"
+        }
+      ]
     }
   ]
 

--- a/examples/repository-creation-template/versions.tf
+++ b/examples/repository-creation-template/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = ">= 6.50.0"
     }
   }
 }

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -147,7 +147,7 @@ After trying this simple example, you might want to explore:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.50.0 |
 
 ## Providers
 

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = ">= 6.50.0"
     }
   }
 }

--- a/examples/with-ecs-integration/README.md
+++ b/examples/with-ecs-integration/README.md
@@ -95,13 +95,13 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.50.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 

--- a/examples/with-ecs-integration/versions.tf
+++ b/examples/with-ecs-integration/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = ">= 6.50.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -291,4 +291,12 @@ resource "aws_ecr_repository_creation_template" "this" {
     }
   }
 
+  dynamic "image_tag_mutability_exclusion_filter" {
+    for_each = each.value.image_tag_mutability_exclusion_filters
+    content {
+      filter      = image_tag_mutability_exclusion_filter.value.filter
+      filter_type = image_tag_mutability_exclusion_filter.value.filter_type
+    }
+  }
+
 }

--- a/modules/kms/README.md
+++ b/modules/kms/README.md
@@ -196,7 +196,7 @@ See the `examples/` directory for complete usage examples.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 

--- a/modules/pull-through-cache/README.md
+++ b/modules/pull-through-cache/README.md
@@ -90,7 +90,7 @@ module "pull_through_cache" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 

--- a/repository.tf
+++ b/repository.tf
@@ -57,6 +57,15 @@ resource "aws_ecr_repository" "repo" {
     }
   }
 
+  # Configure image tag mutability exclusion filters
+  dynamic "image_tag_mutability_exclusion_filter" {
+    for_each = var.image_tag_mutability_exclusion_filters
+    content {
+      filter      = image_tag_mutability_exclusion_filter.value.filter
+      filter_type = image_tag_mutability_exclusion_filter.value.filter_type
+    }
+  }
+
   # Configure image scanning settings
   dynamic "image_scanning_configuration" {
     for_each = local.image_scanning_configuration
@@ -70,6 +79,16 @@ resource "aws_ecr_repository" "repo" {
     for_each = local.timeouts
     content {
       delete = timeouts.value.delete
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition = length(var.image_tag_mutability_exclusion_filters) == 0 || contains(
+        ["IMMUTABLE_WITH_EXCLUSION", "MUTABLE_WITH_EXCLUSION"],
+        var.image_tag_mutability
+      )
+      error_message = "image_tag_mutability_exclusion_filters can only be set when image_tag_mutability is IMMUTABLE_WITH_EXCLUSION or MUTABLE_WITH_EXCLUSION."
     }
   }
 
@@ -92,6 +111,15 @@ resource "aws_ecr_repository" "repo_protected" {
     }
   }
 
+  # Configure image tag mutability exclusion filters
+  dynamic "image_tag_mutability_exclusion_filter" {
+    for_each = var.image_tag_mutability_exclusion_filters
+    content {
+      filter      = image_tag_mutability_exclusion_filter.value.filter
+      filter_type = image_tag_mutability_exclusion_filter.value.filter_type
+    }
+  }
+
   # Configure image scanning settings
   dynamic "image_scanning_configuration" {
     for_each = local.image_scanning_configuration
@@ -111,6 +139,14 @@ resource "aws_ecr_repository" "repo_protected" {
   # Prevent accidental deletion of the repository
   lifecycle {
     prevent_destroy = true
+
+    precondition {
+      condition = length(var.image_tag_mutability_exclusion_filters) == 0 || contains(
+        ["IMMUTABLE_WITH_EXCLUSION", "MUTABLE_WITH_EXCLUSION"],
+        var.image_tag_mutability
+      )
+      error_message = "image_tag_mutability_exclusion_filters can only be set when image_tag_mutability is IMMUTABLE_WITH_EXCLUSION or MUTABLE_WITH_EXCLUSION."
+    }
   }
 
   tags = local.final_tags

--- a/test/fixtures/advanced-tagging/versions.tf
+++ b/test/fixtures/advanced-tagging/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = ">= 6.50.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/test/fixtures/basic/main.tf
+++ b/test/fixtures/basic/main.tf
@@ -7,8 +7,13 @@ module "ecr" {
 
   name                 = var.name
   scan_on_push         = true
-  image_tag_mutability = "IMMUTABLE"
-  force_delete         = true # Set to true for tests to ensure clean teardown
+  image_tag_mutability = "IMMUTABLE_WITH_EXCLUSION"
+  image_tag_mutability_exclusion_filters = [
+    {
+      filter = "latest"
+    }
+  ]
+  force_delete = true # Set to true for tests to ensure clean teardown
 
   tags = {
     Environment = "test"

--- a/test/fixtures/basic/versions.tf
+++ b/test/fixtures/basic/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = ">= 6.50.0"
     }
   }
 }

--- a/test/fixtures/complete/versions.tf
+++ b/test/fixtures/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = ">= 6.50.0"
     }
   }
 }

--- a/test/fixtures/enhanced-security/versions.tf
+++ b/test/fixtures/enhanced-security/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = ">= 6.50.0"
     }
   }
   required_version = ">= 1.0"

--- a/test/fixtures/repository-creation-template/main.tf
+++ b/test/fixtures/repository-creation-template/main.tf
@@ -27,7 +27,12 @@ module "repository_creation_template" {
       prefix               = "ROOT"
       description          = "Default template for ECR-created repositories"
       applied_for          = ["CREATE_ON_PUSH", "REPLICATION"]
-      image_tag_mutability = "IMMUTABLE"
+      image_tag_mutability = "IMMUTABLE_WITH_EXCLUSION"
+      image_tag_mutability_exclusion_filters = [
+        {
+          filter = "latest"
+        }
+      ]
       encryption_configuration = {
         encryption_type = "AES256"
       }
@@ -36,7 +41,12 @@ module "repository_creation_template" {
       prefix               = "docker-hub"
       description          = "Template for pull-through cache repositories"
       applied_for          = ["PULL_THROUGH_CACHE"]
-      image_tag_mutability = "MUTABLE"
+      image_tag_mutability = "MUTABLE_WITH_EXCLUSION"
+      image_tag_mutability_exclusion_filters = [
+        {
+          filter = "release-*"
+        }
+      ]
       lifecycle_policy = jsonencode({
         rules = [
           {

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,31 @@ variable "image_tag_mutability" {
   }
 }
 
+variable "image_tag_mutability_exclusion_filters" {
+  description = "List of image tag mutability exclusion filters. Use only when image_tag_mutability is IMMUTABLE_WITH_EXCLUSION or MUTABLE_WITH_EXCLUSION."
+  type = list(object({
+    filter      = string
+    filter_type = optional(string, "WILDCARD")
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for exclusion_filter in var.image_tag_mutability_exclusion_filters :
+      exclusion_filter.filter_type == "WILDCARD"
+    ])
+    error_message = "Image tag mutability exclusion filter_type must be WILDCARD."
+  }
+
+  validation {
+    condition = alltrue([
+      for exclusion_filter in var.image_tag_mutability_exclusion_filters :
+      can(regex("^[0-9A-Za-z._*-]{1,128}$", exclusion_filter.filter)) && length(regexall("\\*", exclusion_filter.filter)) <= 2
+    ])
+    error_message = "Image tag mutability exclusion filter must be 1-128 characters, contain only letters, numbers, '.', '_', '*', or '-', and include at most two wildcard characters."
+  }
+}
+
 # ----------------------------------------------------------
 # Image Scanning Configuration
 # ----------------------------------------------------------
@@ -522,9 +547,13 @@ variable "repository_creation_templates" {
       kms_key         = optional(string)
     }))
     image_tag_mutability = optional(string, "MUTABLE")
-    lifecycle_policy     = optional(string)
-    repository_policy    = optional(string)
-    resource_tags        = optional(map(string), {})
+    image_tag_mutability_exclusion_filters = optional(list(object({
+      filter      = string
+      filter_type = optional(string, "WILDCARD")
+    })), [])
+    lifecycle_policy  = optional(string)
+    repository_policy = optional(string)
+    resource_tags     = optional(map(string), {})
   }))
   default = []
 
@@ -556,9 +585,40 @@ variable "repository_creation_templates" {
   validation {
     condition = alltrue([
       for template in var.repository_creation_templates :
-      contains(["MUTABLE", "IMMUTABLE"], template.image_tag_mutability)
+      contains(["MUTABLE", "IMMUTABLE", "IMMUTABLE_WITH_EXCLUSION", "MUTABLE_WITH_EXCLUSION"], template.image_tag_mutability)
     ])
-    error_message = "Repository creation template image_tag_mutability must be one of MUTABLE or IMMUTABLE."
+    error_message = "Repository creation template image_tag_mutability must be one of MUTABLE, IMMUTABLE, IMMUTABLE_WITH_EXCLUSION, or MUTABLE_WITH_EXCLUSION."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for template in var.repository_creation_templates : [
+        for exclusion_filter in template.image_tag_mutability_exclusion_filters :
+        exclusion_filter.filter_type == "WILDCARD"
+      ]
+    ]))
+    error_message = "Repository creation template image tag mutability exclusion filter_type must be WILDCARD."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for template in var.repository_creation_templates : [
+        for exclusion_filter in template.image_tag_mutability_exclusion_filters :
+        can(regex("^[0-9A-Za-z._*-]{1,128}$", exclusion_filter.filter)) && length(regexall("\\*", exclusion_filter.filter)) <= 2
+      ]
+    ]))
+    error_message = "Repository creation template image tag mutability exclusion filter must be 1-128 characters, contain only letters, numbers, '.', '_', '*', or '-', and include at most two wildcard characters."
+  }
+
+  validation {
+    condition = alltrue([
+      for template in var.repository_creation_templates :
+      length(template.image_tag_mutability_exclusion_filters) == 0 || contains(
+        ["IMMUTABLE_WITH_EXCLUSION", "MUTABLE_WITH_EXCLUSION"],
+        template.image_tag_mutability
+      )
+    ])
+    error_message = "Repository creation template image_tag_mutability_exclusion_filters can only be set when image_tag_mutability is IMMUTABLE_WITH_EXCLUSION or MUTABLE_WITH_EXCLUSION."
   }
 
   validation {

--- a/versions.tf
+++ b/versions.tf
@@ -6,10 +6,10 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      # Require AWS provider 6.0.0+ for the `region` attribute on the
-      # aws_region data source (which replaced the now-deprecated `id`/`name`).
-      # 6.0.0 also retains ECR account settings support added in 5.81.0.
-      version = ">= 6.0.0"
+      # Require AWS provider 6.50.0+ for ECR image tag mutability
+      # exclusion filters on repositories and repository creation templates.
+      # 6.50.0 also retains the AWS provider v6 aws_region.region schema.
+      version = ">= 6.50.0"
     }
     archive = {
       source  = "hashicorp/archive"


### PR DESCRIPTION
## Summary

- add `image_tag_mutability_exclusion_filters` for root ECR repositories
- wire exclusion filters into both standard and `prevent_destroy` repository resources
- extend repository creation templates with exclusion filters and the `*_WITH_EXCLUSION` mutability modes
- raise the root/example/fixture AWS provider floor to `>= 6.50.0`, where the provider documents these ECR arguments
- refresh generated terraform-docs

Closes #195.

## Notes

Provider source checked: hashicorp/aws latest is 6.53.0; provider docs for `aws_ecr_repository` and `aws_ecr_repository_creation_template` include `image_tag_mutability_exclusion_filter`.