### PR TITLE
fix: repair codebot review trigger

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -108,7 +108,7 @@ jobs:
           esac
 
           # Build comment body safely
-          COMMENT_BODY="codebot $REVIEW_MODE"
+          COMMENT_BODY="@codebot $REVIEW_MODE"
           if [ "${{ github.event.inputs.verbose }}" = "true" ]; then
             COMMENT_BODY="$COMMENT_BODY verbose"
           fi
@@ -590,12 +590,10 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model claude-sonnet-4-6"
-
-          # Allow Bash permissions for pre-commit hooks and documentation updates
-          allowed_tools: "Bash(pre-commit run --files),Bash(terraform fmt),Bash(terraform validate),Bash(terraform-docs)"
+          trigger_phrase: "@codebot"
 
           # Dynamic prompt based on review mode
-          direct_prompt: |
+          prompt: |
             🔄 **COMMIT ANALYSIS CONTEXT**
             - **Commit SHA**: `${{ steps.verify-state.outputs.current_sha }}`
             - **Review ID**: `${{ steps.verify-state.outputs.review_id }}`
@@ -723,18 +721,18 @@ jobs:
           # Available Commands
           echo "### 📝 Available Commands" >> $GITHUB_STEP_SUMMARY
           echo "Comment any of these in PRs to trigger specific review types:" >> $GITHUB_STEP_SUMMARY
-          echo "- \`codebot hunt\` - Quick bug detection (like Bugbot) on PR changes" >> $GITHUB_STEP_SUMMARY
-          echo "- \`codebot analyze\` - Deep technical analysis on PR changes" >> $GITHUB_STEP_SUMMARY
-          echo "- \`codebot security\` - Security-focused review on PR changes" >> $GITHUB_STEP_SUMMARY
-          echo "- \`codebot performance\` - Performance optimization review on PR changes" >> $GITHUB_STEP_SUMMARY
-          echo "- \`codebot review\` - Comprehensive review on PR changes" >> $GITHUB_STEP_SUMMARY
-          echo "- \`codebot\` - Defaults to hunt mode on PR changes" >> $GITHUB_STEP_SUMMARY
+          echo "- \`@codebot hunt\` - Quick bug detection (like Bugbot) on PR changes" >> $GITHUB_STEP_SUMMARY
+          echo "- \`@codebot analyze\` - Deep technical analysis on PR changes" >> $GITHUB_STEP_SUMMARY
+          echo "- \`@codebot security\` - Security-focused review on PR changes" >> $GITHUB_STEP_SUMMARY
+          echo "- \`@codebot performance\` - Performance optimization review on PR changes" >> $GITHUB_STEP_SUMMARY
+          echo "- \`@codebot review\` - Comprehensive review on PR changes" >> $GITHUB_STEP_SUMMARY
+          echo "- \`@codebot\` - Defaults to hunt mode on PR changes" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           # Scope Options
           echo "### 🔍 Scope Options" >> $GITHUB_STEP_SUMMARY
           echo "- Add \`--full\` to any command to analyze the entire codebase" >> $GITHUB_STEP_SUMMARY
-          echo "- Example: \`codebot hunt --full\` - Hunt for bugs in the entire codebase" >> $GITHUB_STEP_SUMMARY
+          echo "- Example: \`@codebot hunt --full\` - Hunt for bugs in the entire codebase" >> $GITHUB_STEP_SUMMARY
           echo "- Default behavior (without --full) focuses only on changed files in the PR" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
@@ -764,4 +762,4 @@ jobs:
           echo "1. Check the commit SHA matches your latest changes" >> $GITHUB_STEP_SUMMARY
           echo "2. Verify the diff detection was successful" >> $GITHUB_STEP_SUMMARY
           echo "3. Review the git state analysis above" >> $GITHUB_STEP_SUMMARY
-          echo "4. Try \`codebot hunt --full\` to analyze the entire codebase" >> $GITHUB_STEP_SUMMARY
+          echo "4. Try \`@codebot hunt --full\` to analyze the entire codebase" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -142,7 +142,7 @@ jobs:
         run: pre-commit install-hooks
 
       - name: Run pre-commit on all files
-        run: pre-commit run --all-files
+        run: pre-commit run --all-files --show-diff-on-failure
 
       - name: Pre-commit summary
         if: always()

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,6 +9,7 @@ on:
       - '**.md'
       - '.pre-commit-config.yaml'
       - '.github/workflows/pre-commit.yml'
+      - '.github/workflows/claude-code-review.yml'
   push:
     branches: [master]
     paths:
@@ -17,6 +18,7 @@ on:
       - '**.md'
       - '.pre-commit-config.yaml'
       - '.github/workflows/pre-commit.yml'
+      - '.github/workflows/claude-code-review.yml'
 
 jobs:
   pre-commit:

--- a/README.md
+++ b/README.md
@@ -1555,8 +1555,8 @@ For more details on the Terraform fixtures, see the [test directory README](test
 
 | Name | Version |
 |------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_archive"></a> [archive](#provider\_archive) | >= 2.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
 
 ## Modules
 
@@ -1862,8 +1862,8 @@ For more details on the discovery system architecture, see `.github/scripts/disc
 
 | Name | Version |
 |------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_archive"></a> [archive](#provider\_archive) | >= 2.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -1555,8 +1555,8 @@ For more details on the Terraform fixtures, see the [test directory README](test
 
 | Name | Version |
 |------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | >= 2.0.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
+| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 
@@ -1862,8 +1862,8 @@ For more details on the discovery system architecture, see `.github/scripts/disc
 
 | Name | Version |
 |------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | >= 2.0.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
+| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -337,7 +337,7 @@ This example serves as a comprehensive reference for production-ready ECR deploy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -337,7 +337,7 @@ This example serves as a comprehensive reference for production-ready ECR deploy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 

--- a/examples/enhanced-kms/README.md
+++ b/examples/enhanced-kms/README.md
@@ -223,7 +223,7 @@ kms_tags = {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 

--- a/examples/enhanced-kms/README.md
+++ b/examples/enhanced-kms/README.md
@@ -223,7 +223,7 @@ kms_tags = {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
 
 ## Modules
 

--- a/examples/enhanced-security/README.md
+++ b/examples/enhanced-security/README.md
@@ -120,7 +120,7 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 

--- a/examples/enhanced-security/README.md
+++ b/examples/enhanced-security/README.md
@@ -120,7 +120,7 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
 
 ## Modules
 

--- a/examples/monitoring/README.md
+++ b/examples/monitoring/README.md
@@ -144,7 +144,7 @@ aws ecr describe-repositories --repository-names my-app
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 

--- a/examples/monitoring/README.md
+++ b/examples/monitoring/README.md
@@ -144,7 +144,7 @@ aws ecr describe-repositories --repository-names my-app
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
 
 ## Modules
 

--- a/examples/multi-region/README.md
+++ b/examples/multi-region/README.md
@@ -137,7 +137,7 @@ Note: You must delete all images from the repositories before they can be delete
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.primary"></a> [aws.primary](#provider\_aws.primary) | 6.51.0 |
+| <a name="provider_aws.primary"></a> [aws.primary](#provider\_aws.primary) | >= 6.0.0 |
 
 ## Modules
 

--- a/examples/multi-region/README.md
+++ b/examples/multi-region/README.md
@@ -137,7 +137,7 @@ Note: You must delete all images from the repositories before they can be delete
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.primary"></a> [aws.primary](#provider\_aws.primary) | >= 6.0.0 |
+| <a name="provider_aws.primary"></a> [aws.primary](#provider\_aws.primary) | 6.53.0 |
 
 ## Modules
 

--- a/examples/protected/README.md
+++ b/examples/protected/README.md
@@ -118,7 +118,7 @@ Remember: Both protection mechanisms must be removed in this order:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
 
 ## Modules
 

--- a/examples/protected/README.md
+++ b/examples/protected/README.md
@@ -118,7 +118,7 @@ Remember: Both protection mechanisms must be removed in this order:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 

--- a/examples/pull-request-rules/README.md
+++ b/examples/pull-request-rules/README.md
@@ -114,7 +114,7 @@ The example can be customized by:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
 
 ## Modules
 

--- a/examples/pull-request-rules/README.md
+++ b/examples/pull-request-rules/README.md
@@ -114,7 +114,7 @@ The example can be customized by:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 

--- a/examples/pull-through-cache/README.md
+++ b/examples/pull-through-cache/README.md
@@ -131,7 +131,7 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
 
 ## Modules
 

--- a/examples/pull-through-cache/README.md
+++ b/examples/pull-through-cache/README.md
@@ -131,7 +131,7 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 

--- a/examples/with-ecs-integration/README.md
+++ b/examples/with-ecs-integration/README.md
@@ -101,7 +101,7 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 

--- a/examples/with-ecs-integration/README.md
+++ b/examples/with-ecs-integration/README.md
@@ -101,7 +101,7 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
 
 ## Modules
 

--- a/modules/kms/README.md
+++ b/modules/kms/README.md
@@ -196,7 +196,7 @@ See the `examples/` directory for complete usage examples.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
 
 ## Modules
 

--- a/modules/kms/README.md
+++ b/modules/kms/README.md
@@ -196,7 +196,7 @@ See the `examples/` directory for complete usage examples.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 

--- a/modules/pull-through-cache/README.md
+++ b/modules/pull-through-cache/README.md
@@ -90,7 +90,7 @@ module "pull_through_cache" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
 
 ## Modules
 

--- a/modules/pull-through-cache/README.md
+++ b/modules/pull-through-cache/README.md
@@ -90,7 +90,7 @@ module "pull_through_cache" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 
 ## Modules
 


### PR DESCRIPTION
## Summary

- make manual workflow dispatch comments include the explicit `@codebot` mention
- configure `anthropics/claude-code-action` to use `trigger_phrase: "@codebot"`
- pass the generated review instructions through the supported `prompt` input instead of the ignored `direct_prompt` input
- remove the unsupported `allowed_tools` input for this pinned action version
- update workflow summary command examples to show `@codebot ...`
- include `claude-code-review.yml` in the pre-commit workflow path filters so workflow repairs exercise CI
- refresh terraform-docs provider-version output required by the all-files pre-commit gate

## Why

The current workflow starts on `@codebot hunt`, but the pinned Claude action still looks for `@claude` internally and ignores `direct_prompt`, causing successful no-op runs with `No trigger found` / `Context prompt: NO PROMPT`.

## Validation

- `git diff --check`
- `pre-commit run --files .github/workflows/claude-code-review.yml .github/workflows/pre-commit.yml`
- `pre-commit run terraform_docs --all-files`