### PR TITLE
ci: extend codebot review timeout

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -585,7 +585,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude
-        timeout-minutes: 10
+        timeout-minutes: 20
         uses: anthropics/claude-code-action@70a6e5256e9e2366a1ed5c041904a982ba3a328f # v1.0.135
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- increase the Claude Code Review step timeout from 10 to 20 minutes

## Why

The repaired `@codebot hunt` trigger now starts Claude and passes the prompt correctly, but PR #202 hit the 10-minute step timeout just after Claude completed its run, before buffered inline comments could be posted.

## Validation

- `git diff --check`
- `pre-commit run --files .github/workflows/claude-code-review.yml`