### PR TITLE
docs: remove AWS-consuming test commands from templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/ecr-bug-fix.md
+++ b/.github/ISSUE_TEMPLATE/ecr-bug-fix.md
@@ -124,19 +124,10 @@ assignees: []
 
 #### Validation Commands
 ```bash
-# Test with examples
-cd examples/[affected-example]
-terraform init -upgrade
+# Validate affected example without creating AWS resources
+terraform -chdir=examples/[affected-example] init -backend=false
+terraform -chdir=examples/[affected-example] validate
 terraform plan
-terraform apply
-terraform destroy
-
-# Run specific tests
-cd test/
-go test -v -timeout 30m -run TestTerraformECR[AffectedFeature]
-
-# Full test suite
-go test -v -timeout 45m ./...
 ```
 
 ### Provider Version Strategy

--- a/.github/ISSUE_TEMPLATE/ecr-bug-fix.md
+++ b/.github/ISSUE_TEMPLATE/ecr-bug-fix.md
@@ -127,7 +127,7 @@ assignees: []
 # Validate affected example without creating AWS resources
 terraform -chdir=examples/[affected-example] init -backend=false
 terraform -chdir=examples/[affected-example] validate
-terraform plan
+terraform -chdir=examples/[affected-example] plan
 ```
 
 ### Provider Version Strategy

--- a/.github/ISSUE_TEMPLATE/ecr-deprecation.md
+++ b/.github/ISSUE_TEMPLATE/ecr-deprecation.md
@@ -81,7 +81,6 @@ assignees: []
 #### Phase 4: Testing & Validation
 - [ ] **Comprehensive Testing**
   - [ ] Test all examples with new implementation
-  - [ ] Run full test suite (`go test ./test/...`)
   - [ ] Validate backward compatibility
   - [ ] Test upgrade scenarios
 - [ ] **Quality Assurance**
@@ -162,9 +161,9 @@ terraform plan
 terraform init -upgrade
 terraform plan
 
-# Run comprehensive tests
-cd test/
-go test -v -timeout 30m
+# Run repository validation checks
+terraform fmt -recursive
+pre-commit run --all-files
 ```
 
 ### Acceptance Criteria

--- a/.github/ISSUE_TEMPLATE/new-ecr-feature.md
+++ b/.github/ISSUE_TEMPLATE/new-ecr-feature.md
@@ -38,7 +38,6 @@ assignees: []
 - [ ] Add to `CHANGELOG.md` (will be automated by release-please)
 
 #### Testing & Validation
-- [ ] Add Terratest in `test/[feature-name]_test.go`
 - [ ] Add test fixtures in `test/fixtures/[feature-name]/`
 - [ ] Test with `examples/complete` scenario
 - [ ] Run `terraform fmt`, `terraform validate`
@@ -80,16 +79,10 @@ output "[feature_output]" {
 
 ### Testing Commands
 ```bash
-# Test the specific example
-cd examples/[feature-name]
-terraform init
+# Validate the specific example without creating AWS resources
+terraform -chdir=examples/[feature-name] init -backend=false
+terraform -chdir=examples/[feature-name] validate
 terraform plan
-terraform apply
-terraform destroy
-
-# Run comprehensive tests
-cd test/
-go test -v -timeout 30m -run TestTerraformECR[FeatureName]
 ```
 
 ### Implementation Notes
@@ -101,7 +94,7 @@ go test -v -timeout 30m -run TestTerraformECR[FeatureName]
 
 ### Acceptance Criteria
 - [ ] Feature implemented following module patterns
-- [ ] All tests pass (`go test ./test/...`)
+- [ ] Targeted validation checks pass
 - [ ] Examples work as documented
 - [ ] Pre-commit hooks pass
 - [ ] Documentation complete and accurate

--- a/.github/ISSUE_TEMPLATE/new-ecr-feature.md
+++ b/.github/ISSUE_TEMPLATE/new-ecr-feature.md
@@ -82,7 +82,7 @@ output "[feature_output]" {
 # Validate the specific example without creating AWS resources
 terraform -chdir=examples/[feature-name] init -backend=false
 terraform -chdir=examples/[feature-name] validate
-terraform plan
+terraform -chdir=examples/[feature-name] plan
 ```
 
 ### Implementation Notes

--- a/README.md
+++ b/README.md
@@ -1556,7 +1556,7 @@ For more details on the Terraform fixtures, see the [test directory README](test
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.55.0 |
 
 ## Modules
 
@@ -1864,7 +1864,7 @@ For more details on the discovery system architecture, see `.github/scripts/disc
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.55.0 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -337,7 +337,7 @@ This example serves as a comprehensive reference for production-ready ECR deploy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.55.0 |
 
 ## Modules
 

--- a/examples/enhanced-kms/README.md
+++ b/examples/enhanced-kms/README.md
@@ -223,7 +223,7 @@ kms_tags = {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.55.0 |
 
 ## Modules
 

--- a/examples/enhanced-security/README.md
+++ b/examples/enhanced-security/README.md
@@ -120,7 +120,7 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.55.0 |
 
 ## Modules
 

--- a/examples/monitoring/README.md
+++ b/examples/monitoring/README.md
@@ -144,7 +144,7 @@ aws ecr describe-repositories --repository-names my-app
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.55.0 |
 
 ## Modules
 

--- a/examples/multi-region/README.md
+++ b/examples/multi-region/README.md
@@ -137,7 +137,7 @@ Note: You must delete all images from the repositories before they can be delete
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.primary"></a> [aws.primary](#provider\_aws.primary) | 6.53.0 |
+| <a name="provider_aws.primary"></a> [aws.primary](#provider\_aws.primary) | 6.55.0 |
 
 ## Modules
 

--- a/examples/protected/README.md
+++ b/examples/protected/README.md
@@ -118,7 +118,7 @@ Remember: Both protection mechanisms must be removed in this order:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.55.0 |
 
 ## Modules
 

--- a/examples/pull-request-rules/README.md
+++ b/examples/pull-request-rules/README.md
@@ -114,7 +114,7 @@ The example can be customized by:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.55.0 |
 
 ## Modules
 

--- a/examples/pull-through-cache/README.md
+++ b/examples/pull-through-cache/README.md
@@ -131,7 +131,7 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.55.0 |
 
 ## Modules
 

--- a/examples/with-ecs-integration/README.md
+++ b/examples/with-ecs-integration/README.md
@@ -101,7 +101,7 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.55.0 |
 
 ## Modules
 

--- a/modules/kms/README.md
+++ b/modules/kms/README.md
@@ -196,7 +196,7 @@ See the `examples/` directory for complete usage examples.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.55.0 |
 
 ## Modules
 

--- a/modules/pull-through-cache/README.md
+++ b/modules/pull-through-cache/README.md
@@ -90,7 +90,7 @@ module "pull_through_cache" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.55.0 |
 
 ## Modules
 


### PR DESCRIPTION
## Summary
- Keep the existing pre-commit workflow, Terraform formatting/validation guidance, and `test/fixtures/*` validation fixtures.
- Remove stale issue-template commands that asked contributors to run AWS-consuming live tests (`terraform apply` / `terraform destroy`) or the old Go/Terratest suite.
- Replace those with non-mutating validation examples (`terraform init -backend=false`, `terraform validate`, `terraform plan`) while preserving pre-commit guidance.
- Refresh generated terraform-docs provider-version output required by the retained pre-commit workflow.

## Notes
- No Terraform module resources, variables, outputs, examples, submodules, workflows, pre-commit config, or validation fixtures are removed.
- This narrows the original cleanup scope to only the resource-consuming test instructions plus generated docs drift needed for CI.

## Validation
- `terraform fmt -check -recursive`
- `git diff --check origin/master`
- `pre-commit run terraform_docs --all-files`
- GitHub `pre-commit` workflow: passing
- Confirmed issue templates no longer reference `terraform apply`, `terraform destroy`, `go test`, `Terratest`, or `cd test/`.
